### PR TITLE
zero: add kustomize

### DIFF
--- a/zero/kustomize/.gitignore
+++ b/zero/kustomize/.gitignore
@@ -1,0 +1,1 @@
+pomerium-secret.yaml

--- a/zero/kustomize/README.md
+++ b/zero/kustomize/README.md
@@ -1,0 +1,43 @@
+# Installing Pomerium Zero
+
+Visit https://console.pomerium.app and register for an account.
+
+# Install base pomerium zero
+
+```shell
+kubectl apply -k https://github.com/pomerium/pomerium/k8s/zero?ref=main
+```
+
+(that would install an evergreen `main`)
+
+# Create a secret with Pomerium Zero token to complete your installation
+
+```yaml filename="pomerium-secret.yaml"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pomerium
+  namespace: pomerium-zero
+type: Opaque
+stringData:
+    pomerium_zero_token:
+```
+
+```shell
+kubectl apply -f pomerium-secret.yaml
+```
+
+Now your Pomerium deployment should be up and running.
+
+# Update Pomerium cluster configuration
+
+1. The externally available address of your Pomerium Cluster should be set to the value assigned by your Load Balancer:
+
+```shell
+kubectl get svc/pomerium-proxy -n pomerium-zero -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+2. Because container is configured to run as non-root, the following should be adjusted:
+
+- http redirect address set to `:8080`
+- server address set to `:8443`

--- a/zero/kustomize/deployment/base.yaml
+++ b/zero/kustomize/deployment/base.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium-zero
+  template:
+    spec:
+      automountServiceAccountToken: true
+      serviceAccountName: pomerium-zero
+      containers:
+        - name: pomerium
+      terminationGracePeriodSeconds: 10

--- a/zero/kustomize/deployment/env.yaml
+++ b/zero/kustomize/deployment/env.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          env:
+            - name: POMERIUM_ZERO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: pomerium_zero_token
+                  optional: false
+            - name: POMERIUM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BOOTSTRAP_CONFIG_FILE
+              value: "/var/run/secrets/pomerium/bootstrap.dat"
+            - name: BOOTSTRAP_CONFIG_WRITEBACK_URI
+              value: "secret://$(POMERIUM_NAMESPACE)/pomerium/bootstrap"
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP

--- a/zero/kustomize/deployment/image.yaml
+++ b/zero/kustomize/deployment/image.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          image: pomerium/pomerium:v0.27.2
+          imagePullPolicy: IfNotFound

--- a/zero/kustomize/deployment/kustomization.yaml
+++ b/zero/kustomize/deployment/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+  - base.yaml
+patchesStrategicMerge:
+  - env.yaml
+  - image.yaml
+  - ports.yaml
+  - resources.yaml
+  - no-root.yaml
+  - readonly-root-fs.yaml
+  - volumes.yaml

--- a/zero/kustomize/deployment/no-root.yaml
+++ b/zero/kustomize/deployment/no-root.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 1000
+        sysctls:
+          - name: net.ipv4.ip_unprivileged_port_start
+            value: "80"
+      containers:
+        - name: pomerium
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL

--- a/zero/kustomize/deployment/ports.yaml
+++ b/zero/kustomize/deployment/ports.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          ports:
+            - containerPort: 443
+              name: https
+              protocol: TCP
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP

--- a/zero/kustomize/deployment/readonly-root-fs.yaml
+++ b/zero/kustomize/deployment/readonly-root-fs.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/zero/kustomize/deployment/resources.yaml
+++ b/zero/kustomize/deployment/resources.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          resources:
+            limits:
+              cpu: 5000m
+              memory: 1Gi
+            requests:
+              cpu: 300m
+              memory: 200Mi

--- a/zero/kustomize/deployment/volumes.yaml
+++ b/zero/kustomize/deployment/volumes.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: pomerium
+          env:
+            - name: TMPDIR
+              value: "/tmp/pomerium"
+            - name: XDG_CACHE_HOME
+              value: "/tmp/pomerium/cache"
+            - name: XDG_DATA_HOME
+              value: "/tmp/pomerium/cache"
+          volumeMounts:
+            - mountPath: "/tmp/pomerium"
+              name: tmp
+            - mountPath: "/var/run/secrets/pomerium"
+              name: bootstrap
+              readOnly: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: bootstrap
+          secret:
+            optional: true
+            secretName: pomerium
+            items:
+              - key: bootstrap
+                path: bootstrap.dat

--- a/zero/kustomize/kustomization.yaml
+++ b/zero/kustomize/kustomization.yaml
@@ -1,0 +1,8 @@
+namespace: pomerium-zero
+commonLabels:
+  app.kubernetes.io/name: pomerium-zero
+resources:
+  - namespace.yaml
+  - ./rbac
+  - ./deployment
+  - ./service

--- a/zero/kustomize/namespace.yaml
+++ b/zero/kustomize/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pomerium-zero

--- a/zero/kustomize/pomerium-secret.yaml.example
+++ b/zero/kustomize/pomerium-secret.yaml.example
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pomerium
+  namespace: pomerium-zero
+type: Opaque
+stringData:
+    pomerium_zero_token: YOUR_TOKEN_HERE

--- a/zero/kustomize/rbac/kustomization.yaml
+++ b/zero/kustomize/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- role.yaml
+- role_binding.yaml
+- service_account.yaml

--- a/zero/kustomize/rbac/role.yaml
+++ b/zero/kustomize/rbac/role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pomerium-zero
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - patch
+    resourceNames:
+      - pomerium

--- a/zero/kustomize/rbac/role_binding.yaml
+++ b/zero/kustomize/rbac/role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pomerium-zero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pomerium-zero
+subjects:
+  - kind: ServiceAccount
+    name: pomerium-zero

--- a/zero/kustomize/rbac/service_account.yaml
+++ b/zero/kustomize/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pomerium-zero

--- a/zero/kustomize/service/kustomization.yaml
+++ b/zero/kustomize/service/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - proxy.yaml

--- a/zero/kustomize/service/proxy.yaml
+++ b/zero/kustomize/service/proxy.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pomerium-proxy
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+    - name: http
+      targetPort: http
+      protocol: TCP
+      port: 80


### PR DESCRIPTION
## Summary

Adds Kustomization manifests that may be used to install Pomerium Zero directly via `kubectl` like:

```
kubectl apply -k github.com/pomerium/install/zero/kustomize
```

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
