### PR TITLE
enterprise: add kubernetes terraform

### DIFF
--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -87,7 +87,7 @@ resource "kubernetes_deployment" "pomerium-console" {
 
           env {
             name  = "AUDIENCE"
-            value = join(",", var.audience)
+            value = join(",", local.audience)
           }
 
           env {
@@ -104,7 +104,7 @@ resource "kubernetes_deployment" "pomerium-console" {
             name = "SHARED_SECRET"
             value_from {
               secret_key_ref {
-                name = var.secrets_name
+                name = local.secrets_name
                 key  = "shared_secret_b64"
               }
             }
@@ -114,7 +114,7 @@ resource "kubernetes_deployment" "pomerium-console" {
             name = "SIGNING_KEY"
             value_from {
               secret_key_ref {
-                name = var.secrets_name
+                name = local.secrets_name
                 key  = "signing_key_b64"
               }
             }
@@ -124,7 +124,7 @@ resource "kubernetes_deployment" "pomerium-console" {
             name = "DATABASE_URL"
             value_from {
               secret_key_ref {
-                name     = var.secrets_name
+                name     = local.secrets_name
                 key      = "database_url"
                 optional = false
               }
@@ -135,7 +135,7 @@ resource "kubernetes_deployment" "pomerium-console" {
             name = "DATABASE_ENCRYPTION_KEY"
             value_from {
               secret_key_ref {
-                name     = var.secrets_name
+                name     = local.secrets_name
                 key      = "database_encryption_key_b64"
                 optional = false
               }
@@ -146,7 +146,7 @@ resource "kubernetes_deployment" "pomerium-console" {
             name = "LICENSE_KEY"
             value_from {
               secret_key_ref {
-                name     = var.secrets_name
+                name     = local.secrets_name
                 key      = "license_key"
                 optional = false
               }

--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -1,0 +1,231 @@
+resource "kubernetes_deployment" "pomerium-console" {
+  metadata {
+    name      = "pomerium-console"
+    namespace = var.namespace_name
+  }
+
+  depends_on = [
+    kubernetes_namespace.pomerium-enterprise,
+    kubernetes_secret.console,
+    kubernetes_secret.docker_registry
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations,
+    ]
+  }
+
+  spec {
+    replicas = var.deployment_replicas
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "pomerium-console"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name" = "pomerium-console"
+        }
+      }
+
+      spec {
+        termination_grace_period_seconds = 30
+
+        service_account_name = kubernetes_service_account.console.metadata[0].name
+
+        security_context {
+          run_as_non_root = true
+
+          seccomp_profile {
+            type = "RuntimeDefault"
+          }
+        }
+
+        os {
+          name = "linux"
+        }
+
+        node_selector = {
+          "kubernetes.io/os" = "linux"
+        }
+
+        image_pull_secrets {
+          name = var.image_pull_secret
+        }
+
+        volume {
+          name = "tmp"
+          empty_dir {
+            size_limit = var.resources_ephemeral_storage
+          }
+        }
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = lookup(toleration.value, "key", null)
+            operator           = lookup(toleration.value, "operator", null)
+            value              = lookup(toleration.value, "value", null)
+            effect             = lookup(toleration.value, "effect", null)
+            toleration_seconds = lookup(toleration.value, "toleration_seconds", null)
+          }
+        }
+
+        container {
+          name              = "pomerium-console"
+          image             = "${var.image_registry}/${var.image_name}:${var.image_tag}"
+          image_pull_policy = var.image_pull_policy
+
+          args = [
+            "--tls-derive=pomerium-console.${var.namespace_name}.svc.cluster.local",
+            "serve",
+          ]
+
+          env {
+            name  = "AUDIENCE"
+            value = join(",", var.audience)
+          }
+
+          env {
+            name  = "ADMINISTRATORS"
+            value = join(",", var.administrators)
+          }
+
+          env {
+            name  = "DATABROKER_SERVICE_URL"
+            value = "https://pomerium-databroker.${var.core_namespace_name}.svc"
+          }
+
+          env {
+            name = "SHARED_SECRET"
+            value_from {
+              secret_key_ref {
+                name = var.secrets_name
+                key  = "shared_secret_b64"
+              }
+            }
+          }
+
+          env {
+            name = "SIGNING_KEY"
+            value_from {
+              secret_key_ref {
+                name = var.secrets_name
+                key  = "signing_key_b64"
+              }
+            }
+          }
+
+          env {
+            name = "DATABASE_URL"
+            value_from {
+              secret_key_ref {
+                name     = var.secrets_name
+                key      = "database_url"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "DATABASE_ENCRYPTION_KEY"
+            value_from {
+              secret_key_ref {
+                name     = var.secrets_name
+                key      = "database_encryption_key_b64"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "LICENSE_KEY"
+            value_from {
+              secret_key_ref {
+                name     = var.secrets_name
+                key      = "license_key"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name  = "LICENSE_KEY_VALIDATE_OFFLINE"
+            value = var.license_key_validate_offline
+          }
+
+          env {
+            name  = "TMPDIR"
+            value = "/tmp"
+          }
+
+          env {
+            name  = "XDG_CACHE_HOME"
+            value = "/tmp"
+          }
+
+          volume_mount {
+            name       = "tmp"
+            mount_path = "/tmp"
+          }
+
+          port {
+            name           = "app"
+            container_port = 8701
+            protocol       = "TCP"
+          }
+
+          port {
+            name           = "grpc-api"
+            container_port = 8702
+            protocol       = "TCP"
+          }
+
+          resources {
+            limits = {
+              cpu                 = var.resources_limits_cpu
+              memory              = var.resources_limits_memory
+              "ephemeral-storage" = var.resources_ephemeral_storage
+            }
+            requests = {
+              cpu                 = var.resources_requests_cpu
+              memory              = var.resources_requests_memory
+              "ephemeral-storage" = var.resources_ephemeral_storage
+            }
+          }
+
+          security_context {
+            read_only_root_filesystem = true
+            capabilities {
+              drop = ["ALL"]
+              add  = []
+            }
+            allow_privilege_escalation = false
+          }
+        }
+
+        dynamic "container" {
+          for_each = var.sidecars
+          content {
+            name  = container.value.name
+            image = container.value.image
+            args  = container.value.args
+            security_context {
+              run_as_non_root            = true
+              allow_privilege_escalation = false
+              read_only_root_filesystem  = true
+              capabilities {
+                drop = ["ALL"]
+                add  = []
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/enterprise/terraform/kubernetes/docker_secret.tf
+++ b/enterprise/terraform/kubernetes/docker_secret.tf
@@ -1,0 +1,20 @@
+resource "kubernetes_secret" "docker_registry" {
+  metadata {
+    name      = var.image_pull_secret
+    namespace = var.namespace_name
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "${var.image_registry}" = {
+          username = var.image_registry_username
+          password = var.image_registry_password
+          auth     = base64encode("${var.image_registry_username}:${var.image_registry_password}")
+        }
+      }
+    })
+  }
+}

--- a/enterprise/terraform/kubernetes/ingress.tf
+++ b/enterprise/terraform/kubernetes/ingress.tf
@@ -1,0 +1,73 @@
+locals {
+  default_ingress_annotations = {
+    "ingress.pomerium.io/pass_identity_headers" = "true"
+    "ingress.pomerium.io/secure_upstream"       = "true"
+  }
+}
+
+resource "kubernetes_ingress_v1" "console" {
+  count = var.console_ingress != null ? 1 : 0
+  metadata {
+    name        = "console"
+    namespace   = var.namespace_name
+    annotations = merge(local.default_ingress_annotations, var.console_ingress.annotations)
+  }
+
+  spec {
+    ingress_class_name = var.ingress_class_name
+
+    rule {
+      host = var.console_ingress.dns
+
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = resource.kubernetes_service.console.metadata[0].name
+              port {
+                name = "https"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "console-api" {
+  count = var.console_api_ingress != null ? 1 : 0
+  metadata {
+    name      = "console-api"
+    namespace = var.namespace_name
+    annotations = merge(
+      local.default_ingress_annotations,
+      var.console_api_ingress.annotations,
+    )
+  }
+
+  spec {
+    ingress_class_name = var.ingress_class_name
+
+    rule {
+      host = var.console_api_ingress.dns
+
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = resource.kubernetes_service.console.metadata[0].name
+              port {
+                name = "grpc"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/enterprise/terraform/kubernetes/locals.tf
+++ b/enterprise/terraform/kubernetes/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  audience = var.audience == [] ? var.audience : [
+    var.console_ingress.dns,
+    var.console_api_ingress.dns,
+  ]
+  secrets_name = "enterprise"
+}

--- a/enterprise/terraform/kubernetes/namespace.tf
+++ b/enterprise/terraform/kubernetes/namespace.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_namespace" "pomerium-enterprise" {
+  metadata {
+    name = var.namespace_name
+  }
+}

--- a/enterprise/terraform/kubernetes/namespace.tf
+++ b/enterprise/terraform/kubernetes/namespace.tf
@@ -1,4 +1,5 @@
 resource "kubernetes_namespace" "pomerium-enterprise" {
+  count = var.use_external_namespace ? 0 : 1
   metadata {
     name = var.namespace_name
   }

--- a/enterprise/terraform/kubernetes/secret.tf
+++ b/enterprise/terraform/kubernetes/secret.tf
@@ -1,0 +1,17 @@
+resource "kubernetes_secret" "console" {
+  metadata {
+    name      = var.secrets_name
+    namespace = var.namespace_name
+  }
+
+  type = "Opaque"
+
+  data = {
+    "license_key"                 = var.license_key
+    "database_url"                = var.database_url
+    "database_encryption_key_b64" = var.database_encryption_key_b64
+    "shared_secret_b64"           = var.shared_secret_b64
+    "signing_key_b64"             = var.signing_key_b64
+  }
+
+}

--- a/enterprise/terraform/kubernetes/secret.tf
+++ b/enterprise/terraform/kubernetes/secret.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_secret" "console" {
   metadata {
-    name      = var.secrets_name
+    name      = local.secrets_name
     namespace = var.namespace_name
   }
 
@@ -9,9 +9,23 @@ resource "kubernetes_secret" "console" {
   data = {
     "license_key"                 = var.license_key
     "database_url"                = var.database_url
-    "database_encryption_key_b64" = var.database_encryption_key_b64
-    "shared_secret_b64"           = var.shared_secret_b64
-    "signing_key_b64"             = var.signing_key_b64
+    "database_encryption_key_b64" = random_bytes.database_encryption_key.base64
+    "shared_secret_b64"           = data.kubernetes_secret.core_secrets.binary_data["shared_secret"]
+    "signing_key_b64"             = data.kubernetes_secret.core_secrets.binary_data["signing_key"]
   }
+}
 
+resource "random_bytes" "database_encryption_key" {
+  length = 32
+}
+
+data "kubernetes_secret" "core_secrets" {
+  metadata {
+    name      = var.bootstrap_secret.name
+    namespace = var.bootstrap_secret.namespace
+  }
+  binary_data = {
+    shared_secret = ""
+    signing_key   = ""
+  }
 }

--- a/enterprise/terraform/kubernetes/service.tf
+++ b/enterprise/terraform/kubernetes/service.tf
@@ -1,0 +1,28 @@
+resource "kubernetes_service" "proxy" {
+  metadata {
+    name      = "pomerium-console"
+    namespace = var.namespace_name
+  }
+
+  spec {
+    selector = {
+      "app.kubernetes.io/name" = "pomerium-console"
+    }
+
+    port {
+      name        = "https"
+      port        = 443
+      target_port = "app"
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "grpc"
+      port        = 5443
+      target_port = "grpc-api"
+      protocol    = "TCP"
+    }
+
+    type = "ClusterIP"
+  }
+}

--- a/enterprise/terraform/kubernetes/service.tf
+++ b/enterprise/terraform/kubernetes/service.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_service" "proxy" {
+resource "kubernetes_service" "console" {
   metadata {
     name      = "pomerium-console"
     namespace = var.namespace_name

--- a/enterprise/terraform/kubernetes/service_account.tf
+++ b/enterprise/terraform/kubernetes/service_account.tf
@@ -1,0 +1,7 @@
+resource "kubernetes_service_account" "console" {
+  metadata {
+    name        = "pomerium-console"
+    namespace   = var.namespace_name
+    annotations = var.service_account_annotations
+  }
+}

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -4,6 +4,12 @@ variable "namespace_name" {
   default     = "pomerium-enterprise"
 }
 
+variable "use_external_namespace" {
+  description = "Skip creating the namespace, assume it already exists, and use the provided namespace name"
+  type        = bool
+  default     = false
+}
+
 variable "image_name" {
   description = "Container image name"
   type        = string

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -64,12 +64,9 @@ variable "tolerations" {
 }
 
 variable "audience" {
-  description = "List of audiences"
+  description = "List of audiences. By default would be derived from the ingress DNS names."
   type        = list(string)
-  validation {
-    condition     = length(var.audience) >= 1
-    error_message = "Audience must be provided"
-  }
+  default     = []
 }
 
 variable "administrators" {
@@ -84,32 +81,9 @@ variable "core_namespace_name" {
   default     = "pomerium-ingress-controller"
 }
 
-variable "authenticate_service_url" {
-  description = "The URL of the authenticate service"
-  type        = string
-}
-
-variable "shared_secret_b64" {
-  description = "Shared secret between the core and console, Base64 encoded binary data"
-  type        = string
-  sensitive   = true
-}
-
-variable "signing_key_b64" {
-  description = "PEM encoded signing key for the console, Base64 encoded"
-  type        = string
-  sensitive   = true
-}
-
 variable "database_url" {
   description = "Postgres database DSN string, may be either URL or key-value format"
   type        = string
-}
-
-variable "database_encryption_key_b64" {
-  description = "Key used to encrypt database data"
-  type        = string
-  sensitive   = true
 }
 
 variable "license_key" {
@@ -117,13 +91,6 @@ variable "license_key" {
   type        = string
   sensitive   = true
 }
-
-variable "secrets_name" {
-  description = "Name of the secrets"
-  type        = string
-  default     = "enterprise"
-}
-
 
 variable "resources_requests" {
   description = "Resource requests for the container"
@@ -194,4 +161,34 @@ variable "license_key_validate_offline" {
   description = "Whether to validate the license key offline. Can only be used with a valid offline license key."
   type        = bool
   default     = false
+}
+
+variable "console_ingress" {
+  description = "Console Ingress configuration. Set to null to disable."
+  type = object({
+    dns         = string
+    annotations = map(string)
+  })
+}
+
+variable "console_api_ingress" {
+  description = "Console API Ingress configuration. Annotations should contain the Pomerium policy. Set to null to disable."
+  type = object({
+    dns         = string
+    annotations = map(string)
+  })
+}
+
+variable "ingress_class_name" {
+  description = "Name of the Ingress class"
+  type        = string
+  default     = "pomerium"
+}
+
+variable "bootstrap_secret" {
+  description = "Reference to the core bootstrap secret to copy shared secrets from"
+  type = object({
+    name      = string
+    namespace = string
+  })
 }

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -1,0 +1,191 @@
+variable "namespace_name" {
+  description = "The name of the namespace to create"
+  type        = string
+  default     = "pomerium-enterprise"
+}
+
+variable "image_name" {
+  description = "Container image name"
+  type        = string
+  default     = "pomerium/enterprise/pomerium-console"
+}
+
+variable "image_tag" {
+  description = "Container image tag"
+  type        = string
+  default     = "v0.27.2"
+}
+
+variable "image_pull_policy" {
+  description = "Image pull policy"
+  type        = string
+  default     = "IfNotPresent"
+}
+
+variable "image_pull_secret" {
+  description = "Name of the Docker registry secret"
+  type        = string
+  default     = "pomerium-enterprise-docker-registry"
+}
+
+variable "image_registry" {
+  description = "Image registry"
+  type        = string
+  default     = "docker.cloudsmith.io"
+}
+
+variable "image_registry_username" {
+  description = "Docker registry username"
+  type        = string
+  default     = "pomerium/enterprise"
+}
+
+variable "image_registry_password" {
+  description = "Docker registry password"
+  type        = string
+}
+
+variable "tolerations" {
+  description = "List of tolerations for the pods."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string, "Equal")
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(number)
+  }))
+  default = []
+}
+
+variable "audience" {
+  description = "List of audiences"
+  type        = list(string)
+  validation {
+    condition     = length(var.audience) >= 1
+    error_message = "Audience must be provided"
+  }
+}
+
+variable "administrators" {
+  description = "List of administrators (emails). this should only be used for the console bootstrap."
+  type        = list(string)
+  default     = []
+}
+
+variable "core_namespace_name" {
+  description = "The name of the namespace Pomerium Core was deployed to"
+  type        = string
+  default     = "pomerium-ingress-controller"
+}
+
+variable "authenticate_service_url" {
+  description = "The URL of the authenticate service"
+  type        = string
+}
+
+variable "shared_secret_b64" {
+  description = "Shared secret between the core and console, Base64 encoded binary data"
+  type        = string
+  sensitive   = true
+}
+
+variable "signing_key_b64" {
+  description = "PEM encoded signing key for the console, Base64 encoded"
+  type        = string
+  sensitive   = true
+}
+
+variable "database_url" {
+  description = "Postgres database DSN string, may be either URL or key-value format"
+  type        = string
+}
+
+variable "database_encryption_key_b64" {
+  description = "Key used to encrypt database data"
+  type        = string
+  sensitive   = true
+}
+
+variable "license_key" {
+  description = "Pomerium license key"
+  type        = string
+  sensitive   = true
+}
+
+variable "secrets_name" {
+  description = "Name of the secrets"
+  type        = string
+  default     = "enterprise"
+}
+
+
+variable "resources_requests" {
+  description = "Resource requests for the container"
+  type = object({
+    cpu               = string
+    memory            = string
+    ephemeral_storage = string
+  })
+  default = {
+    cpu               = "2"
+    memory            = "4Gi"
+    ephemeral_storage = "4Gi"
+  }
+}
+
+variable "resources_limits_cpu" {
+  description = "Resource CPU limits for the container"
+  type        = string
+  default     = "4"
+}
+
+variable "resources_limits_memory" {
+  description = "Resource RAM limits for the container"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "resources_requests_cpu" {
+  description = "Resource CPU requests for the container"
+  type        = string
+  default     = "2"
+}
+
+variable "resources_requests_memory" {
+  description = "Resource RAM requests for the container"
+  type        = string
+  default     = "4Gi"
+}
+
+variable "resources_ephemeral_storage" {
+  description = "Resource ephemeral storage for the container"
+  type        = string
+  default     = "4Gi"
+}
+
+variable "deployment_replicas" {
+  description = "Number of replicas for the Pomerium Enterprise Deployment"
+  type        = number
+  default     = 1
+}
+
+variable "service_account_annotations" {
+  description = "Name of the service account"
+  type        = map(string)
+  default     = {}
+}
+
+variable "sidecars" {
+  description = "Additional sidecar containers to run in the pod"
+  type = list(object({
+    name  = string
+    image = string
+    args  = list(string)
+  }))
+}
+
+variable "license_key_validate_offline" {
+  description = "Whether to validate the license key offline. Can only be used with a valid offline license key."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

Adds Terraform module for Enterprise Console deployment to Kubernetes, while working together with the Ingress Controller.

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
