### PR TITLE
ingress-controller/terraform: add rolling update var

### DIFF
--- a/ingress-controller/terraform/deployment.tf
+++ b/ingress-controller/terraform/deployment.tf
@@ -23,6 +23,14 @@ resource "kubernetes_deployment" "pomerium" {
   spec {
     replicas = var.deployment_replicas
 
+    strategy {
+      type = "RollingUpdate"
+      rolling_update {
+        max_surge       = var.rolling_update.max_surge
+        max_unavailable = var.rolling_update.max_unavailable
+      }
+    }
+
     selector {
       match_labels = local.pod_labels
     }

--- a/ingress-controller/terraform/variables.tf
+++ b/ingress-controller/terraform/variables.tf
@@ -252,3 +252,15 @@ variable "config" {
   })
   default = {}
 }
+
+variable "rolling_update" {
+  description = "Rolling update configuration"
+  type = object({
+    max_surge       = optional(string)
+    max_unavailable = optional(string)
+  })
+  default = {
+    max_surge       = "25%"
+    max_unavailable = "25%"
+  }
+}


### PR DESCRIPTION
## Summary

`RollingUpdate` is default upgrade strategy for `kubernetes_deployment` resource. 
This PR Adds `rolling_update` parameter to customize it. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
