### PR TITLE
tf: support secret rotation

### DIFF
--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -7,7 +7,8 @@ resource "kubernetes_deployment" "pomerium-console" {
   depends_on = [
     kubernetes_namespace.pomerium-enterprise,
     kubernetes_secret.console,
-    kubernetes_secret.docker_registry
+    kubernetes_secret.docker_registry,
+    kubernetes_secret.console,
   ]
 
   lifecycle {
@@ -84,6 +85,11 @@ resource "kubernetes_deployment" "pomerium-console" {
             "--tls-derive=pomerium-console.${var.namespace_name}.svc.cluster.local",
             "serve",
           ]
+
+          env {
+            name  = "CONFIG_HASH"
+            value = md5(jsonencode(kubernetes_secret.console.data))
+          }
 
           env {
             name  = "AUDIENCE"

--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -29,7 +29,8 @@ resource "kubernetes_deployment" "pomerium-console" {
     template {
       metadata {
         labels = {
-          "app.kubernetes.io/name" = "pomerium-console"
+          "app.kubernetes.io/name"      = "pomerium-console"
+          "pomerium.io/config-checksum" = local.config_checksum
         }
       }
 
@@ -87,23 +88,18 @@ resource "kubernetes_deployment" "pomerium-console" {
           ]
 
           env {
-            name  = "CONFIG_HASH"
-            value = md5(jsonencode(kubernetes_secret.console.data))
-          }
-
-          env {
             name  = "AUDIENCE"
-            value = join(",", local.audience)
+            value = join(",", local.config.audience)
           }
 
           env {
             name  = "ADMINISTRATORS"
-            value = join(",", var.administrators)
+            value = join(",", local.config.administrators)
           }
 
           env {
             name  = "DATABROKER_SERVICE_URL"
-            value = "https://pomerium-databroker.${var.core_namespace_name}.svc"
+            value = local.config.databroker_service_url
           }
 
           env {
@@ -161,12 +157,12 @@ resource "kubernetes_deployment" "pomerium-console" {
 
           env {
             name  = "LICENSE_KEY_VALIDATE_OFFLINE"
-            value = var.license_key_validate_offline
+            value = local.config.license_key_validate_offline
           }
 
           env {
             name  = "PROMETHEUS_URL"
-            value = var.prometheus_url
+            value = local.config.prometheus_url
           }
 
           env {

--- a/enterprise/terraform/kubernetes/locals.tf
+++ b/enterprise/terraform/kubernetes/locals.tf
@@ -1,7 +1,20 @@
 locals {
-  audience = var.audience == [] ? var.audience : [
-    var.console_ingress.dns,
-    var.console_api_ingress.dns,
-  ]
+  # keep all config parameters in one place, 
+  # so that if the parameters change, we can adjust the label for a pod, 
+  # that will trigger a rolling update
+  config = {
+    administrators         = var.administrators
+    databroker_service_url = "https://pomerium-databroker.${var.core_namespace_name}.svc"
+    secrets                = kubernetes_secret.console.data
+    audience = var.audience == [] ? var.audience : [
+      var.console_ingress.dns,
+      var.console_api_ingress.dns,
+    ]
+    license_key_validate_offline = var.license_key_validate_offline
+    prometheus_url               = var.prometheus_url
+  }
+
+  config_checksum = md5(jsonencode(local.config))
+
   secrets_name = "enterprise"
 }

--- a/enterprise/terraform/kubernetes/secret.tf
+++ b/enterprise/terraform/kubernetes/secret.tf
@@ -4,6 +4,8 @@ resource "kubernetes_secret" "console" {
     namespace = var.namespace_name
   }
 
+  depends_on = [data.kubernetes_secret.core_secrets]
+
   type = "Opaque"
 
   data = {
@@ -12,6 +14,7 @@ resource "kubernetes_secret" "console" {
     "database_encryption_key_b64" = random_bytes.database_encryption_key.base64
     "shared_secret_b64"           = data.kubernetes_secret.core_secrets.binary_data["shared_secret"]
     "signing_key_b64"             = data.kubernetes_secret.core_secrets.binary_data["signing_key"]
+    "rv"                          = data.kubernetes_secret.core_secrets.metadata[0].resource_version
   }
 }
 

--- a/ingress-controller/terraform/secrets.tf
+++ b/ingress-controller/terraform/secrets.tf
@@ -23,9 +23,21 @@ resource "tls_private_key" "signing_key" {
 
 resource "random_bytes" "shared_secret" {
   length = 32
+  lifecycle {
+    create_before_destroy = true
+  }
+  keepers = {
+    version = var.secrets_version
+  }
 }
 
 resource "random_bytes" "cookie_secret" {
   length = 32
+  lifecycle {
+    create_before_destroy = true
+  }
+  keepers = {
+    version = var.secrets_version
+  }
 }
 

--- a/ingress-controller/terraform/variables.tf
+++ b/ingress-controller/terraform/variables.tf
@@ -252,3 +252,9 @@ variable "config" {
   })
   default = {}
 }
+
+variable "secrets_version" {
+  description = "Version of the secrets. Changing this will cause the secrets to be regenerated."
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
## Summary

Adds `secrets_version` variable to the `pomerium_ingress_controller` module, that can be incremented to make internal secrets rotate. 

That should also update the enterprise console deployment and restart it. 

## Related issues

Fixes #11


## Checklist

- [x] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
