### PR TITLE
enterprise/tf: add prometheus_url arg

### DIFF
--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -159,6 +159,11 @@ resource "kubernetes_deployment" "pomerium-console" {
           }
 
           env {
+            name  = "PROMETHEUS_URL"
+            value = var.prometheus_url
+          }
+
+          env {
             name  = "TMPDIR"
             value = "/tmp"
           }

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -192,3 +192,9 @@ variable "bootstrap_secret" {
     namespace = string
   })
 }
+
+variable "prometheus_url" {
+  description = "URL of the Prometheus server to query for metrics"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Adds `prometheus_url` customization to enterprise terraform. 

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
