### PR TITLE
ic/tf: fix a typo in schema definition

### DIFF
--- a/ingress-controller/terraform/variables.tf
+++ b/ingress-controller/terraform/variables.tf
@@ -232,7 +232,7 @@ variable "config" {
       secret              = string
       url                 = optional(string)
     }))
-    jwtClaimsHeaders            = optional(map(string))
+    jwtClaimHeaders             = optional(map(string))
     passIdentityHeaders         = optional(bool)
     programmaticRedirectDomains = optional(string)
     runtimeFlags                = optional(map(bool))


### PR DESCRIPTION
## Summary

Fix a typo in `jwtClaimHeaders` config option for the ingress-controller.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
