### PR TITLE
recipe/ingress-controller-enterprise-terraform-gke: add prefix to cloud resources

### DIFF
--- a/recipe/ingress-controller-enterprise-terraform-gke/README.md
+++ b/recipe/ingress-controller-enterprise-terraform-gke/README.md
@@ -1,6 +1,7 @@
 module "pomerium_enterprise_gke" {
   source = "git::https://github.com/pomerium/install//recipe/ingress-controller-enterprise-terraform-gke"
 
+  prefix                  = "prod"
   domain                  = "your wildcard domain name"
   license_key             = "pomerium enterprise license key"
   image_registry_password = "pomerium enterprise registry password (provided by Pomerium Sales)"

--- a/recipe/ingress-controller-enterprise-terraform-gke/cloud_sql.tf
+++ b/recipe/ingress-controller-enterprise-terraform-gke/cloud_sql.tf
@@ -14,7 +14,7 @@ resource "google_sql_database_instance" "pomerium" {
 }
 
 locals {
-  db_instance_name = "pomerium"
+  db_instance_name = "${var.prefix}-pomerium"
 
   sql_proxy_sidecar = {
     name  = "cloud-sql-proxy"
@@ -53,8 +53,8 @@ resource "google_sql_user" "pomerium" {
 }
 
 resource "google_service_account" "pomerium" {
-  account_id   = "pomerium"
-  display_name = "Service Account to allow Pomerium to access Cloud SQL"
+  account_id   = "${var.prefix}-pomerium"
+  display_name = "Service Account to allow Pomerium (${var.prefix}) to access Cloud SQL"
 }
 
 locals {

--- a/recipe/ingress-controller-enterprise-terraform-gke/ingress-controller.tf
+++ b/recipe/ingress-controller-enterprise-terraform-gke/ingress-controller.tf
@@ -2,8 +2,8 @@ module "pomerium_ingress_controller" {
   source = "git::https://github.com/pomerium/install//ingress-controller/terraform?ref=main"
 
   enable_databroker = true
-  image_tag         = "main"
-  image_pull_policy = "Always"
+  image_tag         = "sha-8c71989" # pending https://linear.app/pomerium/issue/ENG-1865/installingress-controller-update-ports-in-terraform
+  image_pull_policy = "IfNotPresent"
 }
 
 data "kubernetes_secret" "pomerium_bootstrap" {

--- a/recipe/ingress-controller-enterprise-terraform-gke/variables.tf
+++ b/recipe/ingress-controller-enterprise-terraform-gke/variables.tf
@@ -34,3 +34,9 @@ variable "db_tier" {
   description = "The tier of the database"
   default     = "db-f1-micro"
 }
+
+variable "prefix" {
+  type        = string
+  description = "Prefix to add to all cloud resources for uniqueness"
+  default     = "prod"
+}


### PR DESCRIPTION
## Summary

Adds a prefix to cloud resources so that there could be multiple independent installations within a single cloud project.

## Related issues

https://linear.app/pomerium/issue/ENG-1864/installgke-enterprise-recipe-add-prefix-to-cloud-resources

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
