### PR TITLE
tf/console/k8s: add bootstrap service account option

### DIFF
--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -180,6 +180,11 @@ resource "kubernetes_deployment" "pomerium-console" {
             value = var.validation_mode
           }
 
+          env {
+            name  = "BOOTSTRAP_SERVICE_ACCOUNT"
+            value = var.bootstrap_service_account
+          }
+
           volume_mount {
             name       = "tmp"
             mount_path = "/tmp"

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -208,3 +208,9 @@ variable "validation_mode" {
     error_message = "validation_mode must be one of 'disabled', 'static', or 'full'"
   }
 }
+
+variable "bootstrap_service_account" {
+  description = "Enable a bootstrap service account that may be used by the Terraform Provider to complete the console configuration."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

Adds `bootstrap_service_account` option for Pomerium Enterprise in Kubernetes to enable bootstrap service account in the console that may be used by Terraform Provider to complete configuration. 

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
