### PR TITLE
Reference 0.29 versions of Pomerium

### DIFF
--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -19,7 +19,7 @@ variable "image_name" {
 variable "image_tag" {
   description = "Container image tag"
   type        = string
-  default     = "v0.28.0"
+  default     = "v0.29.0"
 }
 
 variable "image_pull_policy" {

--- a/ingress-controller/terraform/variables.tf
+++ b/ingress-controller/terraform/variables.tf
@@ -34,7 +34,7 @@ variable "image_repository" {
 variable "image_tag" {
   description = "Container image tag"
   type        = string
-  default     = "v0.27.2"
+  default     = "v0.29.2"
 }
 
 variable "image_pull_policy" {

--- a/zero/helm/Chart.yaml
+++ b/zero/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pomerium-zero
 description: A Helm chart for deploying Pomerium Zero
 type: application
-version: 0.27.2
-appVersion: "v0.27.2"
+version: 0.29.2
+appVersion: "v0.29.2"
 home: https://www.pomerium.com/
 icon: https://www.pomerium.com/static-img/favicon.svg
 sources:


### PR DESCRIPTION
Zero's helm chart references 0.29.2 of Core as it is the latest patch release.
Ingress Controller was also patched shortly after release, so 0.29.2 is referenced.
Enterprise Console's latest version is 0.29.0.

Fixes #27 