### PR TITLE
Updated content of ingress-controller .crd from source repo

### DIFF
--- a/ingress-controller/kustomize/crd/bases/ingress.pomerium.io_pomerium.yaml
+++ b/ingress-controller/kustomize/crd/bases/ingress.pomerium.io_pomerium.yaml
@@ -14,352 +14,498 @@ spec:
     singular: pomerium
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          Pomerium define runtime-configurable Pomerium settings
-          that do not fall into the category of deployment parameters
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: PomeriumSpec defines Pomerium-specific configuration parameters.
-            properties:
-              accessLogFields:
-                description: AccessLogFields sets the <a href="https://www.pomerium.com/docs/reference/access-log-fields">access
-                  fields</a> to log.
-                items:
-                  type: string
-                type: array
-              authenticate:
-                description: |-
-                  Authenticate sets authenticate service parameters.
-                  If not specified, a Pomerium-hosted authenticate service would be used.
-                properties:
-                  callbackPath:
-                    description: |-
-                      CallbackPath sets the path at which the authenticate service receives callback responses
-                      from your identity provider. The value must exactly match one of the authorized redirect URIs for the OAuth 2.0 client.
-
-
-                      <p>This value is referred to as the redirect_url in the OpenIDConnect and OAuth2 specs.</p>
-                      <p>Defaults to <code>/oauth2/callback</code></p>
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Pomerium define runtime-configurable Pomerium settings
+            that do not fall into the category of deployment parameters
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PomeriumSpec defines Pomerium-specific configuration parameters.
+              properties:
+                accessLogFields:
+                  description:
+                    AccessLogFields sets the <a href="https://www.pomerium.com/docs/reference/access-log-fields">access
+                    fields</a> to log.
+                  items:
                     type: string
-                  url:
-                    description: "AuthenticateURL is a dedicated domain URL\nthe non-authenticated
-                      persons would be referred to.\n\n\n<p><ul>\n <li>You do not
-                      need to create a dedicated <code>Ingress</code> for this\n\t\tvirtual
-                      route, as it is handled by Pomerium internally. </li>\n\t<li>You
-                      do need create a secret with corresponding TLS certificate for
-                      this route\n\t\tand reference it via <a href=\"#prop-certificates\"><code>certificates</code></a>.\n\t\tIf
-                      you use <code>cert-manager</code> with <code>HTTP01</code> challenge,\n\t\tyou
-                      may use <code>pomerium</code> <code>ingressClass</code> to solve
-                      it.</li>\n</ul></p>"
-                    format: uri
-                    pattern: ^https://
-                    type: string
-                required:
-                - url
-                type: object
-              authorizeLogFields:
-                description: AuthorizeLogFields sets the <a href="https://www.pomerium.com/docs/reference/authorize-log-fields">authorize
-                  fields</a> to log.
-                items:
-                  type: string
-                type: array
-              caSecrets:
-                description: CASecret should refer to k8s secrets with key <code>ca.crt</code>
-                  containing a CA certificate.
-                items:
-                  type: string
-                type: array
-              certificates:
-                description: Certificates is a list of secrets of type TLS to use
-                format: namespace/name
-                items:
-                  type: string
-                type: array
-              cookie:
-                description: Cookie defines Pomerium session cookie options.
-                properties:
-                  domain:
-                    description: |-
-                      Domain defaults to the same host that set the cookie.
-                      If you specify the domain explicitly, then subdomains would also be included.
-                    type: string
-                  expire:
-                    description: |-
-                      Expire sets cookie and Pomerium session expiration time.
-                      Once session expires, users would have to re-login.
-                      If you change this parameter, existing sessions are not affected.
-                      <p>See <a href="https://www.pomerium.com/docs/enterprise/about#session-management">Session Management</a>
-                      (Enterprise) for a more fine-grained session controls.</p>
-                      <p>Defaults to 14 hours.</p>
-                    format: duration
-                    type: string
-                  httpOnly:
-                    description: |-
-                      HTTPOnly if set to <code>false</code>, the cookie would be accessible from within the JavaScript.
-                      Defaults to <code>true</code>.
-                    type: boolean
-                  name:
-                    description: |-
-                      Name sets the Pomerium session cookie name.
-                      Defaults to <code>_pomerium</code>
-                    type: string
-                  sameSite:
-                    description: |-
-                      SameSite sets the SameSite option for cookies.
-                      Defaults to <code></code>.
-                    enum:
-                    - strict
-                    - lax
-                    - none
-                    type: string
-                type: object
-              identityProvider:
-                description: |-
-                  IdentityProvider configure single-sign-on authentication and user identity details
-                  by integrating with your <a href="https://www.pomerium.com/docs/identity-providers/">Identity Provider</a>
-                properties:
-                  provider:
-                    description: |-
-                      Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication.
-                      To use a generic provider, set to <code>oidc</code>.
-                    enum:
-                    - auth0
-                    - azure
-                    - github
-                    - gitlab
-                    - google
-                    - oidc
-                    - okta
-                    - onelogin
-                    - ping
-                    type: string
-                  refreshDirectory:
-                    description: |-
-                      RefreshDirectory is no longer supported,
-                      please see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
-                    properties:
-                      interval:
-                        description: interval is the time that pomerium will sync
-                          your IDP directory.
-                        format: duration
-                        type: string
-                      timeout:
-                        description: timeout is the maximum time allowed each run.
-                        format: duration
-                        type: string
-                    required:
-                    - interval
-                    - timeout
-                    type: object
-                  requestParams:
-                    additionalProperties:
-                      type: string
-                    description: RequestParams to be added as part of a sign-in request
-                      using OAuth2 code flow.
-                    format: namespace/name
-                    type: object
-                  requestParamsSecret:
-                    description: RequestParamsSecret is a reference to a secret for
-                      additional parameters you'd prefer not to provide in plaintext.
-                    format: namespace/name
-                    type: string
-                  scopes:
-                    description: |-
-                      Scopes Identity provider scopes correspond to access privilege scopes
-                      as defined in Section 3.3 of OAuth 2.0 RFC6749.
-                    items:
-                      type: string
-                    type: array
-                  secret:
-                    description: |-
-                      Secret containing IdP provider specific parameters.
-                      and must contain at least <code>client_id</code> and <code>client_secret</code> values.
-                    format: namespace/name
-                    minLength: 1
-                    type: string
-                  serviceAccountFromSecret:
-                    description: |-
-                      ServiceAccountFromSecret is no longer supported,
-                      see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
-                    type: string
-                  url:
-                    description: |-
-                      URL is the base path to an identity provider's OpenID connect discovery document.
-                      See <a href="https://pomerium.com/docs/identity-providers">Identity Providers</a> guides for details.
-                    format: uri
-                    pattern: ^https://
-                    type: string
-                required:
-                - provider
-                - secret
-                type: object
-              jwtClaimHeaders:
-                additionalProperties:
-                  type: string
-                description: |-
-                  JWTClaimHeaders convert claims from the assertion token
-                  into HTTP headers and adds them into JWT assertion header.
-                  Please make sure to read
-                  <a href="https://www.pomerium.com/docs/topics/getting-users-identity">
-                  Getting User Identity</a> guide.
-                type: object
-              passIdentityHeaders:
-                description: PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass
-                  identity headers</a> option.
-                type: boolean
-              programmaticRedirectDomains:
-                description: |-
-                  ProgrammaticRedirectDomains specifies a list of domains that can be used for
-                  <a href="https://www.pomerium.com/docs/capabilities/programmatic-access">programmatic redirects</a>.
-                items:
-                  type: string
-                type: array
-              runtimeFlags:
-                additionalProperties:
-                  type: boolean
-                description: RuntimeFlags sets the <a href="https://www.pomerium.com/docs/reference/runtime-flags">runtime
-                  flags</a> to enable/disable certain features.
-                type: object
-              secrets:
-                description: "Secrets references a Secret with Pomerium bootstrap
-                  parameters.\n\n\n<p>\n<ul>\n\t<li><a href=\"https://pomerium.com/docs/reference/shared-secret\"><code>shared_secret</code></a>\n\t\t-
-                  secures inter-Pomerium service communications.\n\t</li>\n\t<li><a
-                  href=\"https://pomerium.com/docs/reference/cookie-secret\"><code>cookie_secret</code></a>\n\t\t-
-                  encrypts Pomerium session browser cookie.\n\t\tSee also other <a
-                  href=\"#cookie\">Cookie</a> parameters.\n\t</li>\n\t<li><a href=\"https://pomerium.com/docs/reference/signing-key\"><code>signing_key</code></a>\n\t\tsigns
-                  Pomerium JWT assertion header. See\n\t\t<a href=\"https://www.pomerium.com/docs/topics/getting-users-identity\">Getting
-                  the user's identity</a>\n\t\tguide.\n\t</li>\n</ul>\n</p>\n<p>\nIn
-                  a default Pomerium installation manifest, they would be generated
-                  via a\n<a href=\"https://github.com/pomerium/ingress-controller/blob/main/config/gen_secrets/job.yaml\">one-time
-                  job</a>\nand stored in a <code>pomerium/bootstrap</code> Secret.\nYou
-                  may re-run the job to rotate the secrets, or update the Secret values
-                  manually.\n</p>"
-                format: namespace/name
-                minLength: 1
-                type: string
-              setResponseHeaders:
-                additionalProperties:
-                  type: string
-                description: |-
-                  SetResponseHeaders specifies a mapping of HTTP Header to be added globally to all managed routes and pomerium's authenticate service.
-                  See <a href="https://www.pomerium.com/docs/reference/set-response-headers">Set Response Headers</a>
-                type: object
-              storage:
-                description: |-
-                  Storage defines persistent storage for sessions and other data.
-                  See <a href="https://www.pomerium.com/docs/topics/data-storage">Storage</a> for details.
-                  If no storage is specified, Pomerium would use a transient in-memory storage (not recommended for production).
-                properties:
-                  postgres:
-                    description: Postgres specifies PostgreSQL database connection
-                      parameters
-                    properties:
-                      caSecret:
-                        description: |-
-                          CASecret should refer to a k8s secret with key <code>ca.crt</code> containing CA certificate
-                          that, if specified, would be used to populate <code>sslrootcert</code> parameter of the connection string.
-                        format: namespace/name
-                        minLength: 1
-                        type: string
-                      secret:
-                        description: |-
-                          Secret specifies a name of a Secret that must contain
-                          <code>connection</code> key. See
-                          <a href="https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING">DSN Format and Parameters</a>.
-                          Do not set <code>sslrootcert</code>, <code>sslcert</code> and <code>sslkey</code> via connection string,
-                          use <code>tlsSecret</code> and <code>caSecret</code> CRD options instead.
-                        format: namespace/name
-                        minLength: 1
-                        type: string
-                      tlsSecret:
-                        description: |-
-                          TLSSecret should refer to a k8s secret of type <code>kubernetes.io/tls</code>
-                          and allows to specify an optional client certificate and key,
-                          by constructing <code>sslcert</code> and <code>sslkey</code> connection string
-                          <a href="https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS">
-                          parameter values</a>.
-                        format: namespace/name
-                        minLength: 1
-                        type: string
-                    required:
-                    - secret
-                    type: object
-                type: object
-              timeouts:
-                description: Timeout specifies the <a href="https://www.pomerium.com/docs/reference/global-timeouts">global
-                  timeouts</a> for all routes.
-                properties:
-                  idle:
-                    description: Idle specifies the time at which a downstream or
-                      upstream connection will be terminated if there are no active
-                      streams.
-                    format: duration
-                    type: string
-                  read:
-                    description: Read specifies the amount of time for the entire
-                      request stream to be received from the client.
-                    format: duration
-                    type: string
-                  write:
-                    description: |-
-                      Write specifies max stream duration is the maximum time that a stream’s lifetime will span.
-                      An HTTP request/response exchange fully consumes a single stream.
-                      Therefore, this value must be greater than read_timeout as it covers both request and response time.
-                    format: duration
-                    type: string
-                type: object
-              useProxyProtocol:
-                description: UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">Proxy
-                  Protocol</a> support.
-                type: boolean
-            required:
-            - secrets
-            type: object
-          status:
-            description: PomeriumStatus represents configuration and Ingress status.
-            properties:
-              ingress:
-                additionalProperties:
+                  type: array
+                authenticate:
                   description: |-
-                    ResourceStatus represents the outcome of the latest attempt to reconcile
-                    relevant Kubernetes resource with Pomerium.
+                    Authenticate sets authenticate service parameters.
+                    If not specified, a Pomerium-hosted authenticate service would be used.
+                  properties:
+                    callbackPath:
+                      description: |-
+                        CallbackPath sets the path at which the authenticate service receives callback responses
+                        from your identity provider. The value must exactly match one of the authorized redirect URIs for the OAuth 2.0 client.
+
+
+                        <p>This value is referred to as the redirect_url in the OpenIDConnect and OAuth2 specs.</p>
+                        <p>Defaults to <code>/oauth2/callback</code></p>
+                      type: string
+                    url:
+                      description:
+                        "AuthenticateURL is a dedicated domain URL\nthe non-authenticated
+                        persons would be referred to.\n\n\n<p><ul>\n <li>You do not
+                        need to create a dedicated <code>Ingress</code> for this\n\t\tvirtual
+                        route, as it is handled by Pomerium internally. </li>\n\t<li>You
+                        do need create a secret with corresponding TLS certificate for
+                        this route\n\t\tand reference it via <a href=\"#prop-certificates\"><code>certificates</code></a>.\n\t\tIf
+                        you use <code>cert-manager</code> with <code>HTTP01</code> challenge,\n\t\tyou
+                        may use <code>pomerium</code> <code>ingressClass</code> to solve
+                        it.</li>\n</ul></p>"
+                      format: uri
+                      pattern: ^https://
+                      type: string
+                  required:
+                    - url
+                  type: object
+                authorizeLogFields:
+                  description:
+                    AuthorizeLogFields sets the <a href="https://www.pomerium.com/docs/reference/authorize-log-fields">authorize
+                    fields</a> to log.
+                  items:
+                    type: string
+                  type: array
+                bearerTokenFormat:
+                  description:
+                    BearerTokenFormat sets the <a href="https://www.pomerium.com/docs/reference/bearer-token-format">Bearer
+                    Token Format</a>.
+                  enum:
+                    - default
+                    - idp_access_token
+                    - idp_identity_token
+                  type: string
+                caSecrets:
+                  description:
+                    CASecret should refer to k8s secrets with key <code>ca.crt</code>
+                    containing a CA certificate.
+                  items:
+                    type: string
+                  type: array
+                certificates:
+                  description: Certificates is a list of secrets of type TLS to use
+                  format: namespace/name
+                  items:
+                    type: string
+                  type: array
+                codecType:
+                  description:
+                    CodecType sets the <a href="https://www.pomerium.com/docs/reference/codec-type">Codec
+                    Type</a>.
+                  enum:
+                    - auto
+                    - http1
+                    - http2
+                    - http3
+                  type: string
+                cookie:
+                  description: Cookie defines Pomerium session cookie options.
+                  properties:
+                    domain:
+                      description: |-
+                        Domain defaults to the same host that set the cookie.
+                        If you specify the domain explicitly, then subdomains would also be included.
+                      type: string
+                    expire:
+                      description: |-
+                        Expire sets cookie and Pomerium session expiration time.
+                        Once session expires, users would have to re-login.
+                        If you change this parameter, existing sessions are not affected.
+                        <p>See <a href="https://www.pomerium.com/docs/enterprise/about#session-management">Session Management</a>
+                        (Enterprise) for a more fine-grained session controls.</p>
+                        <p>Defaults to 14 hours.</p>
+                      format: duration
+                      type: string
+                    httpOnly:
+                      description: |-
+                        HTTPOnly if set to <code>false</code>, the cookie would be accessible from within the JavaScript.
+                        Defaults to <code>true</code>.
+                      type: boolean
+                    name:
+                      description: |-
+                        Name sets the Pomerium session cookie name.
+                        Defaults to <code>_pomerium</code>
+                      type: string
+                    sameSite:
+                      description: |-
+                        SameSite sets the SameSite option for cookies.
+                        Defaults to <code></code>.
+                      enum:
+                        - strict
+                        - lax
+                        - none
+                      type: string
+                  type: object
+                identityProvider:
+                  description: |-
+                    IdentityProvider configure single-sign-on authentication and user identity details
+                    by integrating with your <a href="https://www.pomerium.com/docs/identity-providers/">Identity Provider</a>
+                  properties:
+                    provider:
+                      description: |-
+                        Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication.
+                        To use a generic provider, set to <code>oidc</code>.
+                      enum:
+                        - auth0
+                        - azure
+                        - github
+                        - gitlab
+                        - google
+                        - oidc
+                        - okta
+                        - onelogin
+                        - ping
+                      type: string
+                    refreshDirectory:
+                      description: |-
+                        RefreshDirectory is no longer supported,
+                        please see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
+                      properties:
+                        interval:
+                          description:
+                            interval is the time that pomerium will sync
+                            your IDP directory.
+                          format: duration
+                          type: string
+                        timeout:
+                          description: timeout is the maximum time allowed each run.
+                          format: duration
+                          type: string
+                      required:
+                        - interval
+                        - timeout
+                      type: object
+                    requestParams:
+                      additionalProperties:
+                        type: string
+                      description:
+                        RequestParams to be added as part of a sign-in request
+                        using OAuth2 code flow.
+                      format: namespace/name
+                      type: object
+                    requestParamsSecret:
+                      description:
+                        RequestParamsSecret is a reference to a secret for
+                        additional parameters you'd prefer not to provide in plaintext.
+                      format: namespace/name
+                      type: string
+                    scopes:
+                      description: |-
+                        Scopes Identity provider scopes correspond to access privilege scopes
+                        as defined in Section 3.3 of OAuth 2.0 RFC6749.
+                      items:
+                        type: string
+                      type: array
+                    secret:
+                      description: |-
+                        Secret containing IdP provider specific parameters.
+                        and must contain at least <code>client_id</code> and <code>client_secret</code> values.
+                      format: namespace/name
+                      minLength: 1
+                      type: string
+                    serviceAccountFromSecret:
+                      description: |-
+                        ServiceAccountFromSecret is no longer supported,
+                        see <a href="https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync">Upgrade Guide</a>.
+                      type: string
+                    url:
+                      description: |-
+                        URL is the base path to an identity provider's OpenID connect discovery document.
+                        See <a href="https://pomerium.com/docs/identity-providers">Identity Providers</a> guides for details.
+                      format: uri
+                      pattern: ^https://
+                      type: string
+                  required:
+                    - provider
+                    - secret
+                  type: object
+                idpAccessTokenAllowedAudiences:
+                  description: |-
+                    IDPAccessTokenAllowedAudiences specifies the
+                    <a href="https://www.pomerium.com/docs/reference/idp-access-token-allowed-audiences">idp access token allowed audiences</a>
+                    list.
+                  items:
+                    type: string
+                  type: array
+                jwtClaimHeaders:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    JWTClaimHeaders convert claims from the assertion token
+                    into HTTP headers and adds them into JWT assertion header.
+                    Please make sure to read
+                    <a href="https://www.pomerium.com/docs/topics/getting-users-identity">
+                    Getting User Identity</a> guide.
+                  type: object
+                otel:
+                  description:
+                    OTEL sets the <a href="https://www.pomerium.com/docs/reference/tracing.mdx">OpenTelemetry
+                    Tracing</a>.
+                  properties:
+                    bspMaxExportBatchSize:
+                      description:
+                        BSPMaxExportBatchSize sets the maximum number of
+                        spans to export in a single batch
+                      format: int32
+                      type: integer
+                    bspScheduleDelay:
+                      description:
+                        BSPScheduleDelay sets interval between two consecutive
+                        exports
+                      format: duration
+                      type: string
+                    endpoint:
+                      description:
+                        "An OTLP/gRPC or OTLP/HTTP base endpoint URL with
+                        optional port.<br/>Example: `http://localhost:4318`"
+                      type: string
+                    headers:
+                      additionalProperties:
+                        type: string
+                      description: Extra headers
+                      type: object
+                    logLevel:
+                      description:
+                        LogLevel sets the log level for the OpenTelemetry
+                        SDK.
+                      enum:
+                        - trace
+                        - debug
+                        - info
+                        - warn
+                        - error
+                      type: string
+                    protocol:
+                      description: Valid values are `"grpc"` or `"http/protobuf"`.
+                      enum:
+                        - grpc
+                        - http/protobuf
+                      type: string
+                    resourceAttributes:
+                      additionalProperties:
+                        type: string
+                      description:
+                        ResourceAttributes sets the additional attributes
+                        to be added to the trace.
+                      type: object
+                    sampling:
+                      description: Sampling sets sampling probability between [0, 1].
+                      format: number
+                      type: string
+                    timeout:
+                      description: Export request timeout duration
+                      format: duration
+                      type: string
+                  required:
+                    - endpoint
+                    - protocol
+                  type: object
+                passIdentityHeaders:
+                  description:
+                    PassIdentityHeaders sets the <a href="https://www.pomerium.com/docs/reference/pass-identity-headers">pass
+                    identity headers</a> option.
+                  type: boolean
+                programmaticRedirectDomains:
+                  description: |-
+                    ProgrammaticRedirectDomains specifies a list of domains that can be used for
+                    <a href="https://www.pomerium.com/docs/capabilities/programmatic-access">programmatic redirects</a>.
+                  items:
+                    type: string
+                  type: array
+                runtimeFlags:
+                  additionalProperties:
+                    type: boolean
+                  description:
+                    RuntimeFlags sets the <a href="https://www.pomerium.com/docs/reference/runtime-flags">runtime
+                    flags</a> to enable/disable certain features.
+                  type: object
+                secrets:
+                  description:
+                    "Secrets references a Secret with Pomerium bootstrap
+                    parameters.\n\n\n<p>\n<ul>\n\t<li><a href=\"https://pomerium.com/docs/reference/shared-secret\"><code>shared_secret</code></a>\n\t\t-
+                    secures inter-Pomerium service communications.\n\t</li>\n\t<li><a
+                    href=\"https://pomerium.com/docs/reference/cookie-secret\"><code>cookie_secret</code></a>\n\t\t-
+                    encrypts Pomerium session browser cookie.\n\t\tSee also other <a
+                    href=\"#cookie\">Cookie</a> parameters.\n\t</li>\n\t<li><a href=\"https://pomerium.com/docs/reference/signing-key\"><code>signing_key</code></a>\n\t\tsigns
+                    Pomerium JWT assertion header. See\n\t\t<a href=\"https://www.pomerium.com/docs/topics/getting-users-identity\">Getting
+                    the user's identity</a>\n\t\tguide.\n\t</li>\n</ul>\n</p>\n<p>\nIn
+                    a default Pomerium installation manifest, they would be generated
+                    via a\n<a href=\"https://github.com/pomerium/ingress-controller/blob/main/config/gen_secrets/job.yaml\">one-time
+                    job</a>\nand stored in a <code>pomerium/bootstrap</code> Secret.\nYou
+                    may re-run the job to rotate the secrets, or update the Secret values
+                    manually.\n</p>"
+                  format: namespace/name
+                  minLength: 1
+                  type: string
+                setResponseHeaders:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    SetResponseHeaders specifies a mapping of HTTP Header to be added globally to all managed routes and pomerium's authenticate service.
+                    See <a href="https://www.pomerium.com/docs/reference/set-response-headers">Set Response Headers</a>
+                  type: object
+                storage:
+                  description: |-
+                    Storage defines persistent storage for sessions and other data.
+                    See <a href="https://www.pomerium.com/docs/topics/data-storage">Storage</a> for details.
+                    If no storage is specified, Pomerium would use a transient in-memory storage (not recommended for production).
+                  properties:
+                    postgres:
+                      description:
+                        Postgres specifies PostgreSQL database connection
+                        parameters
+                      properties:
+                        caSecret:
+                          description: |-
+                            CASecret should refer to a k8s secret with key <code>ca.crt</code> containing CA certificate
+                            that, if specified, would be used to populate <code>sslrootcert</code> parameter of the connection string.
+                          format: namespace/name
+                          minLength: 1
+                          type: string
+                        secret:
+                          description: |-
+                            Secret specifies a name of a Secret that must contain
+                            <code>connection</code> key. See
+                            <a href="https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING">DSN Format and Parameters</a>.
+                            Do not set <code>sslrootcert</code>, <code>sslcert</code> and <code>sslkey</code> via connection string,
+                            use <code>tlsSecret</code> and <code>caSecret</code> CRD options instead.
+                          format: namespace/name
+                          minLength: 1
+                          type: string
+                        tlsSecret:
+                          description: |-
+                            TLSSecret should refer to a k8s secret of type <code>kubernetes.io/tls</code>
+                            and allows to specify an optional client certificate and key,
+                            by constructing <code>sslcert</code> and <code>sslkey</code> connection string
+                            <a href="https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS">
+                            parameter values</a>.
+                          format: namespace/name
+                          minLength: 1
+                          type: string
+                      required:
+                        - secret
+                      type: object
+                  type: object
+                timeouts:
+                  description:
+                    Timeout specifies the <a href="https://www.pomerium.com/docs/reference/global-timeouts">global
+                    timeouts</a> for all routes.
+                  properties:
+                    idle:
+                      description:
+                        Idle specifies the time at which a downstream or
+                        upstream connection will be terminated if there are no active
+                        streams.
+                      format: duration
+                      type: string
+                    read:
+                      description:
+                        Read specifies the amount of time for the entire
+                        request stream to be received from the client.
+                      format: duration
+                      type: string
+                    write:
+                      description: |-
+                        Write specifies max stream duration is the maximum time that a stream’s lifetime will span.
+                        An HTTP request/response exchange fully consumes a single stream.
+                        Therefore, this value must be greater than read_timeout as it covers both request and response time.
+                      format: duration
+                      type: string
+                  type: object
+                useProxyProtocol:
+                  description:
+                    UseProxyProtocol enables <a href="https://www.pomerium.com/docs/reference/use-proxy-protocol">Proxy
+                    Protocol</a> support.
+                  type: boolean
+              required:
+                - secrets
+              type: object
+            status:
+              description: PomeriumStatus represents configuration and Ingress status.
+              properties:
+                ingress:
+                  additionalProperties:
+                    description: |-
+                      ResourceStatus represents the outcome of the latest attempt to reconcile
+                      relevant Kubernetes resource with Pomerium.
+                    properties:
+                      error:
+                        description:
+                          Error that prevented latest observedGeneration
+                          to be synchronized with Pomerium.
+                        type: string
+                      observedAt:
+                        description:
+                          ObservedAt is when last reconciliation attempt
+                          was made.
+                        format: date-time
+                        type: string
+                      observedGeneration:
+                        description:
+                          ObservedGeneration represents the <code>.metadata.generation</code>
+                          that was last presented to Pomerium.
+                        format: int64
+                        type: integer
+                      reconciled:
+                        description:
+                          Reconciled is whether this object generation was
+                          successfully synced with pomerium.
+                        type: boolean
+                      warnings:
+                        description: Warnings while parsing the resource.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - reconciled
+                    type: object
+                  description: Routes provide per-Ingress status.
+                  type: object
+                settingsStatus:
+                  description:
+                    SettingsStatus represent most recent main configuration
+                    reconciliation status.
                   properties:
                     error:
-                      description: Error that prevented latest observedGeneration
-                        to be synchronized with Pomerium.
+                      description:
+                        Error that prevented latest observedGeneration to
+                        be synchronized with Pomerium.
                       type: string
                     observedAt:
-                      description: ObservedAt is when last reconciliation attempt
-                        was made.
+                      description:
+                        ObservedAt is when last reconciliation attempt was
+                        made.
                       format: date-time
                       type: string
                     observedGeneration:
-                      description: ObservedGeneration represents the <code>.metadata.generation</code>
+                      description:
+                        ObservedGeneration represents the <code>.metadata.generation</code>
                         that was last presented to Pomerium.
                       format: int64
                       type: integer
                     reconciled:
-                      description: Reconciled is whether this object generation was
+                      description:
+                        Reconciled is whether this object generation was
                         successfully synced with pomerium.
                       type: boolean
                     warnings:
@@ -368,43 +514,11 @@ spec:
                         type: string
                       type: array
                   required:
-                  - reconciled
+                    - reconciled
                   type: object
-                description: Routes provide per-Ingress status.
-                type: object
-              settingsStatus:
-                description: SettingsStatus represent most recent main configuration
-                  reconciliation status.
-                properties:
-                  error:
-                    description: Error that prevented latest observedGeneration to
-                      be synchronized with Pomerium.
-                    type: string
-                  observedAt:
-                    description: ObservedAt is when last reconciliation attempt was
-                      made.
-                    format: date-time
-                    type: string
-                  observedGeneration:
-                    description: ObservedGeneration represents the <code>.metadata.generation</code>
-                      that was last presented to Pomerium.
-                    format: int64
-                    type: integer
-                  reconciled:
-                    description: Reconciled is whether this object generation was
-                      successfully synced with pomerium.
-                    type: boolean
-                  warnings:
-                    description: Warnings while parsing the resource.
-                    items:
-                      type: string
-                    type: array
-                required:
-                - reconciled
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
## Summary

OpenAI pointed out that the pomerium/install copy of ingress-controller's .crd is out of date. Copied updated content here.
https://github.com/pomerium/ingress-controller/blob/main/config/crd/bases/ingress.pomerium.io_pomerium.yaml

## Related issues
SUP-96

## Checklist

- [X] reference any related issues
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
