### PR TITLE
Removes unused `resources_requests` variable

### DIFF
--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -92,20 +92,6 @@ variable "license_key" {
   sensitive   = true
 }
 
-variable "resources_requests" {
-  description = "Resource requests for the container"
-  type = object({
-    cpu               = string
-    memory            = string
-    ephemeral_storage = string
-  })
-  default = {
-    cpu               = "2"
-    memory            = "4Gi"
-    ephemeral_storage = "4Gi"
-  }
-}
-
 variable "resources_limits_cpu" {
   description = "Resource CPU limits for the container"
   type        = string


### PR DESCRIPTION
This variable is not used. Instead, the object is built using individual `resources_requests_*` variables here: https://github.com/pomerium/install/blob/952f529f6f6e54f992124cbb7c4263dd49c11e83/enterprise/terraform/kubernetes/deployment.tf#L205-L216
 