### PR TITLE
Adds a new min_ready_seconds variable

### DIFF
--- a/ingress-controller/terraform/deployment.tf
+++ b/ingress-controller/terraform/deployment.tf
@@ -21,7 +21,8 @@ resource "kubernetes_deployment" "pomerium" {
   }
 
   spec {
-    replicas = var.deployment_replicas
+    replicas          = var.deployment_replicas
+    min_ready_seconds = var.min_ready_seconds
 
     strategy {
       type = "RollingUpdate"

--- a/ingress-controller/terraform/variables.tf
+++ b/ingress-controller/terraform/variables.tf
@@ -244,13 +244,13 @@ variable "config" {
       })
     }))
     timeouts = optional(object({
-      idle   = optional(string)
-      read   = optional(string)
-      write  = optional(string)
+      idle  = optional(string)
+      read  = optional(string)
+      write = optional(string)
     }))
     otel = optional(object({
-      endpoint              = string                 # required
-      protocol              = string                 # required
+      endpoint              = string # required
+      protocol              = string # required
       headers               = optional(map(string))
       timeout               = optional(string)
       sampling              = optional(number)
@@ -274,6 +274,12 @@ variable "rolling_update" {
     max_surge       = "25%"
     max_unavailable = "25%"
   }
+}
+
+variable "min_ready_seconds" {
+  description = "Minimum number of seconds for which a newly created pod should be ready without any of its containers crashing."
+  type        = number
+  default     = 0
 }
 
 variable "secrets_version" {


### PR DESCRIPTION
This PR provides a way to specify a delay between updates to replicas, by setting the [minReadySeconds](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds) setting on the controller Deployment.

It also makes some minor formatting changes as a result of running `terraform fmt`.