### PR TITLE
pass shared_secret and signing_key via direct module outputs

### DIFF
--- a/enterprise/terraform/kubernetes/secret.tf
+++ b/enterprise/terraform/kubernetes/secret.tf
@@ -4,31 +4,17 @@ resource "kubernetes_secret" "console" {
     namespace = var.namespace_name
   }
 
-  depends_on = [data.kubernetes_secret.core_secrets]
-
   type = "Opaque"
 
   data = {
     "license_key"                 = var.license_key
     "database_url"                = var.database_url
     "database_encryption_key_b64" = random_bytes.database_encryption_key.base64
-    "shared_secret_b64"           = data.kubernetes_secret.core_secrets.binary_data["shared_secret"]
-    "signing_key_b64"             = data.kubernetes_secret.core_secrets.binary_data["signing_key"]
-    "rv"                          = data.kubernetes_secret.core_secrets.metadata[0].resource_version
+    "shared_secret_b64"           = var.shared_secret_b64
+    "signing_key_b64"             = var.signing_key_b64
   }
 }
 
 resource "random_bytes" "database_encryption_key" {
   length = 32
-}
-
-data "kubernetes_secret" "core_secrets" {
-  metadata {
-    name      = var.bootstrap_secret.name
-    namespace = var.bootstrap_secret.namespace
-  }
-  binary_data = {
-    shared_secret = ""
-    signing_key   = ""
-  }
 }

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -171,12 +171,16 @@ variable "ingress_class_name" {
   default     = "pomerium"
 }
 
-variable "bootstrap_secret" {
-  description = "Reference to the core bootstrap secret to copy shared secrets from"
-  type = object({
-    name      = string
-    namespace = string
-  })
+variable "shared_secret_b64" {
+  description = "Base64-encoded shared secret from the Pomerium Core / Ingress controller"
+  type        = string
+  sensitive   = true
+}
+
+variable "signing_key_b64" {
+  description = "Base64-encoded signing key from the Pomerium Core / Ingress controller"
+  type        = string
+  sensitive   = true
 }
 
 variable "prometheus_url" {

--- a/ingress-controller/terraform/outputs.tf
+++ b/ingress-controller/terraform/outputs.tf
@@ -1,6 +1,9 @@
-output "bootstrap_secret" {
-  value = {
-    name      = kubernetes_secret.bootstrap.metadata[0].name
-    namespace = kubernetes_secret.bootstrap.metadata[0].namespace
-  }
+output "shared_secret_b64" {
+  value     = random_bytes.shared_secret.base64
+  sensitive = true
+}
+
+output "signing_key_b64" {
+  value     = base64encode(tls_private_key.signing_key.private_key_pem)
+  sensitive = true
 }

--- a/recipe/ingress-controller-enterprise-terraform-gke/enterprise.tf
+++ b/recipe/ingress-controller-enterprise-terraform-gke/enterprise.tf
@@ -37,10 +37,8 @@ module "pomerium_enterprise" {
   console_ingress     = local.console_ingress
   console_api_ingress = local.console_api_ingress
 
-  bootstrap_secret = {
-    name      = module.pomerium_ingress_controller.bootstrap_secret.name
-    namespace = module.pomerium_ingress_controller.bootstrap_secret.namespace
-  }
+  shared_secret_b64 = module.pomerium_ingress_controller.shared_secret_b64
+  signing_key_b64   = module.pomerium_ingress_controller.signing_key_b64
 
   service_account_annotations = {
     "iam.gke.io/gcp-service-account" = google_service_account.pomerium.email

--- a/recipe/ingress-controller-enterprise-terraform-gke/ingress-controller.tf
+++ b/recipe/ingress-controller-enterprise-terraform-gke/ingress-controller.tf
@@ -8,10 +8,3 @@ module "pomerium_ingress_controller" {
   use_clustered_databroker          = var.use_clustered_databroker
   clustered_databroker_cluster_size = var.clustered_databroker_cluster_size
 }
-
-data "kubernetes_secret" "pomerium_bootstrap" {
-  metadata {
-    name      = module.pomerium_ingress_controller.bootstrap_secret.name
-    namespace = module.pomerium_ingress_controller.bootstrap_secret.namespace
-  }
-}


### PR DESCRIPTION
## Summary

Refactors the secret passing between the ingress controller and enterprise console to use direct values instead of referencing via kubernetes secret. 

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
