### PR TITLE
enterprise: fix databroker service url port

### DIFF
--- a/enterprise/terraform/kubernetes/locals.tf
+++ b/enterprise/terraform/kubernetes/locals.tf
@@ -10,7 +10,7 @@ locals {
         "https://pomerium-databroker-${i}.pomerium-databroker.${var.core_namespace_name}.svc:5443"
       ] :
       [
-        "https://pomerium-databroker.${var.core_namespace_name}.svc"
+        "https://pomerium-databroker.${var.core_namespace_name}.svc:5443"
       ]
     )
     secrets = kubernetes_secret.console.data

--- a/enterprise/terraform/kubernetes/providers.tf
+++ b/enterprise/terraform/kubernetes/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

databroker service is headless, thus we need an explicit port. 

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
