### PR TITLE
console: add disable-remote-diagnostics

### DIFF
--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -195,6 +195,11 @@ resource "kubernetes_deployment" "pomerium-console" {
             value = var.bootstrap_service_account
           }
 
+          env {
+            name  = "DISABLE_REMOTE_DIAGNOSTICS"
+            value = var.disable_remote_diagnostics
+          }
+
           volume_mount {
             name       = "tmp"
             mount_path = "/tmp"

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -216,3 +216,9 @@ variable "clustered_databroker_cluster_size" {
   type        = number
   default     = 3
 }
+
+variable "disable_remote_diagnostics" {
+  description = "Disable remote diagnostics for the Pomerium Enterprise console"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

Adds `disable_remote_diagnostics` flag for the enterprise console that would disable Sentry reporting. 

## Related issues

<!-- For example...
Fixes #159
-->

## Checklist

- [ ] reference any related issues
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
