### PR TITLE
helm: use StatefulSet with PVC for persistent storage

### DIFF
--- a/.github/workflows/helm-dev.yaml
+++ b/.github/workflows/helm-dev.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Helm CLI
         run: |
           curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/helm-dev.yaml
+++ b/.github/workflows/helm-dev.yaml
@@ -12,8 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Helm CLI
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Set dev version
         run: |
           SHORT_SHA="${GITHUB_SHA::7}"

--- a/.github/workflows/helm-dev.yaml
+++ b/.github/workflows/helm-dev.yaml
@@ -1,0 +1,31 @@
+name: Publish Helm Chart (dev)
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "zero/helm/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Helm CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Set dev version
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          VERSION="0.0.0-git.${SHORT_SHA}"
+          sed -i "s/^version:.*/version: ${VERSION}/" ./zero/helm/Chart.yaml
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+      - name: Login
+        run: |
+          helm registry login registry-1.docker.io --username="${{ secrets.DOCKERHUB_USER }}" --password="${{ secrets.DOCKERHUB_SECRET_1124 }}"
+      - name: Package Chart
+        run: |
+          helm package ./zero/helm
+      - name: Push Chart
+        run: |
+          find . -maxdepth 1 -type f -name "pomerium-zero-*.tgz" -exec helm push {} oci://registry-1.docker.io/pomerium \;

--- a/.github/workflows/helm-dev.yaml
+++ b/.github/workflows/helm-dev.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Helm CLI
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Set dev version

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -1,0 +1,25 @@
+name: Helm Chart Tests
+on:
+  pull_request:
+    paths:
+      - "zero/helm/**"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Helm CLI
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+      - name: Lint
+        run: helm lint ./zero/helm
+      - name: Template (StatefulSet)
+        run: helm template pomerium-zero ./zero/helm --set pomeriumZeroToken=test-token
+      - name: Template (Deployment)
+        run: helm template pomerium-zero ./zero/helm --set pomeriumZeroToken=test-token --set persistence.enabled=false
+      - name: Unit Tests
+        run: ./zero/helm/tests/helm_test.sh

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Helm CLI
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Login

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Helm CLI
         run: |
           curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -10,8 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Helm CLI
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       - name: Login
         run: |
           helm registry login registry-1.docker.io --username="${{ secrets.DOCKERHUB_USER }}" --password="${{ secrets.DOCKERHUB_SECRET_1124 }}"

--- a/zero/helm/Chart.yaml
+++ b/zero/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pomerium-zero
 description: A Helm chart for deploying Pomerium Zero
 type: application
-version: 0.31.0
-appVersion: v0.31.0
+version: 0.32.5
+appVersion: v0.32.5
 home: https://www.pomerium.com/
 icon: https://www.pomerium.com/static-img/favicon.svg
 sources:

--- a/zero/helm/Makefile
+++ b/zero/helm/Makefile
@@ -1,0 +1,19 @@
+.PHONY: lint test template clean
+
+lint:
+	helm lint .
+
+test: lint
+	./tests/helm_test.sh
+
+template:
+	helm template test . --set pomeriumZeroToken=test-token
+
+template-deployment:
+	helm template test . --set pomeriumZeroToken=test-token --set persistence.enabled=false
+
+clean:
+	rm -rf charts/ *.tgz
+
+package: lint test
+	helm package .

--- a/zero/helm/README.md
+++ b/zero/helm/README.md
@@ -14,7 +14,7 @@ This Helm chart deploys Pomerium Zero, an identity-aware access proxy, on a Kube
 
 ```sh
 helm install pomerium-zero oci://docker.io/pomerium/pomerium-zero \
-  --create-namespace -n pomerium-zero \
+  -n pomerium-zero \
   --set pomeriumZeroToken=your-pomerium-zero-token
 ```
 
@@ -25,7 +25,7 @@ git clone https://github.com/pomerium/install.git
 cd install/zero/helm
 
 helm install pomerium-zero . \
-  --create-namespace -n pomerium-zero \
+  -n pomerium-zero \
   --set pomeriumZeroToken=your-pomerium-zero-token
 ```
 
@@ -42,6 +42,7 @@ helm uninstall pomerium-zero -n pomerium-zero
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `pomeriumZeroToken` | Pomerium Zero token (required) | `""` |
+| `createNamespace` | Create the target namespace | `true` |
 | `image.repository` | Image repository | `pomerium/pomerium` |
 | `image.tag` | Image tag (defaults to appVersion) | `""` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
@@ -59,7 +60,7 @@ Specify parameters using `--set key=value` or provide a YAML values file:
 
 ```sh
 helm install pomerium-zero oci://docker.io/pomerium/pomerium-zero \
-  --create-namespace -n pomerium-zero -f values.yaml
+  -n pomerium-zero -f values.yaml
 ```
 
 ### Persistence
@@ -70,7 +71,7 @@ To disable persistence and use the legacy **Deployment** mode (bootstrap config 
 
 ```sh
 helm install pomerium-zero oci://docker.io/pomerium/pomerium-zero \
-  --create-namespace -n pomerium-zero \
+  -n pomerium-zero \
   --set pomeriumZeroToken=your-token \
   --set persistence.enabled=false
 ```

--- a/zero/helm/README.md
+++ b/zero/helm/README.md
@@ -10,62 +10,117 @@ This Helm chart deploys Pomerium Zero, an identity-aware access proxy, on a Kube
 
 ## Installing the Chart
 
-`helm install my-release oci://docker.io/pomerium/pomerium-zero --set pomeriumZeroToken=your-pomerium-zero-token`
+### From OCI Registry
+
+```sh
+helm install pomerium-zero oci://docker.io/pomerium/pomerium-zero \
+  --create-namespace -n pomerium-zero \
+  --set pomeriumZeroToken=your-pomerium-zero-token
+```
+
+### From Source
+
+```sh
+git clone https://github.com/pomerium/install.git
+cd install/zero/helm
+
+helm install pomerium-zero . \
+  --create-namespace -n pomerium-zero \
+  --set pomeriumZeroToken=your-pomerium-zero-token
+```
 
 **Note:** Replace `your-pomerium-zero-token` with your actual Pomerium Zero token.
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
-
-`helm uninstall my-release`
+```sh
+helm uninstall pomerium-zero -n pomerium-zero
+```
 
 ## Configuration
 
-The following table lists the configurable parameters of the Pomerium Zero chart and their default values.
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `pomeriumZeroToken` | Pomerium Zero token (required) | `""` |
+| `image.repository` | Image repository | `pomerium/pomerium` |
+| `image.tag` | Image tag (defaults to appVersion) | `""` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `replicaCount` | Number of replicas | `1` |
+| `resources` | CPU/Memory resource requests/limits | `{}` |
+| `service.type` | Service type | `LoadBalancer` |
+| `service.port` | Service port | `443` |
+| `service.nodePort` | NodePort (when service.type is NodePort) | |
+| `persistence.enabled` | Use StatefulSet with PVC for persistent storage | `true` |
+| `persistence.storageClass` | Storage class (empty uses cluster default) | `""` |
+| `persistence.size` | PVC size | `1Gi` |
+| `persistence.accessModes` | PVC access modes | `[ReadWriteOnce]` |
 
-| Parameter           | Description                         | Default             |
-| ------------------- | ----------------------------------- | ------------------- |
-| `pomeriumZeroToken` | Pomerium Zero token (required)      | `""`                |
-| `image.repository`  | Image repository                    | `pomerium/pomerium` |
-| `image.tag`         | Image tag                           | `v0.30.0`           |
-| `image.pullPolicy`  | Image pull policy                   | `IfNotPresent`      |
-| `replicaCount`      | Number of replicas                  | `1`                 |
-| `resources`         | CPU/Memory resource requests/limits | `{}`                |
-| `service.type`      | Service type                        | `ClusterIP`         |
-| `service.port`      | Service port                        | `443`               |
+Specify parameters using `--set key=value` or provide a YAML values file:
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+```sh
+helm install pomerium-zero oci://docker.io/pomerium/pomerium-zero \
+  --create-namespace -n pomerium-zero -f values.yaml
+```
 
-`helm install my-release oci://docker.io/pomerium/pomerium-zero --set pomeriumZeroToken=your-pomerium-zero-token,replicaCount=2`
+### Persistence
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example:
+By default, the chart deploys a **StatefulSet** with a PersistentVolumeClaim for databroker state and bootstrap configuration. This means data survives pod restarts without requiring RBAC permissions to write back to Kubernetes Secrets.
 
-`helm install my-release oci://docker.io/pomerium/pomerium-zero -f values.yaml`
+To disable persistence and use the legacy **Deployment** mode (bootstrap config stored in a Kubernetes Secret):
+
+```sh
+helm install pomerium-zero oci://docker.io/pomerium/pomerium-zero \
+  --create-namespace -n pomerium-zero \
+  --set pomeriumZeroToken=your-token \
+  --set persistence.enabled=false
+```
 
 ## Upgrading the Chart
 
-To upgrade the `my-release` deployment:
-
-`helm upgrade my-release oci://docker.io/pomerium/pomerium-zero --set pomeriumZeroToken=your-pomerium-zero-token`
+```sh
+helm upgrade pomerium-zero oci://docker.io/pomerium/pomerium-zero \
+  -n pomerium-zero \
+  --set pomeriumZeroToken=your-pomerium-zero-token
+```
 
 ## Exposing Pomerium Zero
 
 This Helm chart deploys Pomerium Zero with a LoadBalancer service type, making it externally accessible. This configuration is suitable for cloud environments that support LoadBalancer services.
 
-### Important Notes:
+### Important Notes
 
 1. **LoadBalancer IP**: After deployment, it may take a few minutes for the LoadBalancer IP to be assigned. You can check the status using:
 
-   ```
-   kubectl get svc -n <namespace> <release-name>
+   ```sh
+   kubectl get svc -n pomerium-zero
    ```
 
 2. **Firewall Rules**: Depending on your environment, you may need to configure firewall rules or security groups to allow traffic to the LoadBalancer.
 
 3. **Costs**: Be aware that using a LoadBalancer service may incur additional costs in cloud environments.
 
-Remember to properly secure your Pomerium Zero instance to ensure the safety of your applications and data.
+## Development
+
+### Prerequisites
+
+- [helm](https://helm.sh/docs/intro/install/)
+- [yq](https://github.com/mikefarah/yq)
+
+### Testing
+
+```sh
+make test
+```
+
+### Makefile Targets
+
+| Target | Description |
+| --- | --- |
+| `make lint` | Run `helm lint` |
+| `make test` | Lint + run unit tests |
+| `make template` | Render templates (StatefulSet mode) |
+| `make template-deployment` | Render templates (Deployment mode) |
+| `make package` | Lint, test, and package chart |
 
 ## Support
 

--- a/zero/helm/templates/_helpers.tpl
+++ b/zero/helm/templates/_helpers.tpl
@@ -58,3 +58,143 @@ Validate required values
 {{- fail "pomeriumZeroToken is required. Please set it in your values.yaml or provide it via --set flag." -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Pod spec shared between Deployment and StatefulSet
+*/}}
+{{- define "pomerium-zero.podSpec" -}}
+serviceAccountName: pomerium-zero
+securityContext:
+  {{- toYaml .Values.podSecurityContext | nindent 2 }}
+containers:
+  - name: {{ .Chart.Name }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    env:
+      - name: POMERIUM_ZERO_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ include "pomerium-zero.fullname" . }}
+            key: pomerium_zero_token
+      - name: POMERIUM_NAMESPACE
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
+      - name: POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      {{- if .Values.persistence.enabled }}
+      - name: TMPDIR
+        value: /tmp/pomerium
+      - name: XDG_CACHE_HOME
+        value: /tmp/pomerium/cache
+      - name: XDG_DATA_HOME
+        value: /data
+      - name: BOOTSTRAP_CONFIG_FILE
+        value: /data/bootstrap.dat
+      - name: BOOTSTRAP_CONFIG_WRITEBACK_URI
+        value: file:///data/bootstrap.dat
+      {{- else }}
+      - name: BOOTSTRAP_CONFIG_FILE
+        value: "/var/run/secrets/pomerium/bootstrap.dat"
+      - name: BOOTSTRAP_CONFIG_WRITEBACK_URI
+        value: "secret://$(POMERIUM_NAMESPACE)/{{ include "pomerium-zero.fullname" . }}/bootstrap"
+      - name: XDG_CACHE_HOME
+        value: /tmp/pomerium/cache
+      - name: XDG_DATA_HOME
+        value: /tmp/pomerium/cache
+      {{- end }}
+      {{- with .Values.extraEnvVars }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    ports:
+      - containerPort: 443
+        name: https
+        protocol: TCP
+      - containerPort: 9090
+        name: metrics
+        protocol: TCP
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
+      {{- if .Values.persistence.enabled }}
+      - name: data
+        mountPath: /data
+      {{- else }}
+      - name: bootstrap
+        mountPath: /var/run/secrets/pomerium
+        readOnly: true
+      {{- end }}
+      {{- with .Values.extraVolumeMounts }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    resources:
+      {{- toYaml .Values.resources | nindent 6 }}
+    securityContext:
+      {{- toYaml .Values.securityContext | nindent 6 }}
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: https
+        scheme: HTTPS
+      timeoutSeconds: 1
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: https
+        scheme: HTTPS
+      initialDelaySeconds: 5
+      timeoutSeconds: 1
+      periodSeconds: 5
+      successThreshold: 1
+      failureThreshold: 60
+  {{- with .Values.extraContainers }}
+  {{ toYaml . | nindent 2 }}
+  {{- end }}
+{{- with .Values.initContainers }}
+initContainers:
+  {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if .Values.priorityClassName }}
+priorityClassName: {{ .Values.priorityClassName | quote }}
+{{- end }}
+{{- if .Values.runtimeClassName }}
+runtimeClassName: {{ .Values.runtimeClassName | quote }}
+{{- end }}
+volumes:
+  - name: tmp
+    emptyDir: {}
+  {{- if not .Values.persistence.enabled }}
+  - name: bootstrap
+    secret:
+      items:
+      - key: bootstrap
+        path: bootstrap.dat
+      optional: true
+      secretName: {{ include "pomerium-zero.fullname" . }}
+  {{- end }}
+  {{- with .Values.extraVolumes }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end -}}

--- a/zero/helm/templates/namespace.yaml
+++ b/zero/helm/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.createNamespace -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "pomerium-zero.labels" . | nindent 4 }}
+{{- end }}

--- a/zero/helm/templates/rbac.yaml
+++ b/zero/helm/templates/rbac.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "pomerium-zero.labels" . | nindent 4 }}
   name: pomerium-zero
+{{- if not .Values.persistence.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -35,3 +36,4 @@ subjects:
 - kind: ServiceAccount
   name: pomerium-zero
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/zero/helm/templates/statefulset.yaml
+++ b/zero/helm/templates/statefulset.yaml
@@ -1,12 +1,13 @@
-{{- if not .Values.persistence.enabled -}}
+{{- if .Values.persistence.enabled -}}
 {{- include "pomerium-zero.validateValues" . -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "pomerium-zero.fullname" . }}
   labels:
     {{- include "pomerium-zero.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "pomerium-zero.fullname" . }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
@@ -21,4 +22,18 @@ spec:
       {{- end }}
     spec:
       {{- include "pomerium-zero.podSpec" . | nindent 6 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- range .Values.persistence.accessModes }}
+          - {{ . }}
+          {{- end }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
 {{- end }}

--- a/zero/helm/tests/helm_test.sh
+++ b/zero/helm/tests/helm_test.sh
@@ -141,6 +141,21 @@ assert_eq "custom image" "$(echo "$ss" | yq '.spec.template.spec.containers[0].i
 
 echo ""
 
+# ─── Namespace ────────────────────────────────────────────────────────
+
+echo "Suite: Namespace"
+
+out="$(render -n pomerium-zero)"
+ns="$(select_kind "$out" "Namespace")"
+assert_eq "creates Namespace by default" "$(echo "$ns" | yq '.kind')" "Namespace"
+assert_eq "namespace name matches release namespace" "$(echo "$ns" | yq '.metadata.name')" "pomerium-zero"
+
+out="$(render -n pomerium-zero --set createNamespace=false)"
+ns="$(select_kind "$out" "Namespace")"
+assert_eq "no Namespace when createNamespace=false" "$(echo "$ns" | yq '.kind')" "null"
+
+echo ""
+
 # ─── Validation ──────────────────────────────────────────────────────
 
 echo "Suite: Validation"

--- a/zero/helm/tests/helm_test.sh
+++ b/zero/helm/tests/helm_test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Unit tests for pomerium-zero Helm chart
+# Requires: helm, yq
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FAILURES=0
+TESTS=0
+
+pass() { TESTS=$((TESTS + 1)); echo "  PASS: $1"; }
+fail() { TESTS=$((TESTS + 1)); FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; echo "        $2"; }
+
+assert_eq() {
+  local desc="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then pass "$desc"
+  else fail "$desc" "got '$got', want '$want'"; fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -qF "$needle"; then pass "$desc"
+  else fail "$desc" "output does not contain '$needle'"; fi
+}
+
+assert_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if ! echo "$haystack" | grep -qF "$needle"; then pass "$desc"
+  else fail "$desc" "output should not contain '$needle'"; fi
+}
+
+# Helper: render template and select documents by kind
+render() { helm template test "$CHART_DIR" --set pomeriumZeroToken=test-token "$@" 2>&1; }
+select_kind() { echo "$1" | yq -N 'select(.kind == "'"$2"'")'; }
+
+# ─── StatefulSet (persistence enabled, default) ──────────────────────
+
+echo "Suite: StatefulSet (persistence enabled)"
+
+out="$(render)"
+ss="$(select_kind "$out" "StatefulSet")"
+
+assert_eq "renders StatefulSet" "$(echo "$ss" | yq '.kind')" "StatefulSet"
+assert_eq "serviceName matches fullname" "$(echo "$ss" | yq '.spec.serviceName')" "test-pomerium-zero"
+assert_eq "replicas default 1" "$(echo "$ss" | yq '.spec.replicas')" "1"
+assert_eq "PVC name is data" "$(echo "$ss" | yq '.spec.volumeClaimTemplates[0].metadata.name')" "data"
+assert_eq "PVC size is 1Gi" "$(echo "$ss" | yq '.spec.volumeClaimTemplates[0].spec.resources.requests.storage')" "1Gi"
+assert_eq "PVC access mode" "$(echo "$ss" | yq '.spec.volumeClaimTemplates[0].spec.accessModes[0]')" "ReadWriteOnce"
+assert_eq "no storageClassName by default" "$(echo "$ss" | yq '.spec.volumeClaimTemplates[0].spec.storageClassName')" "null"
+
+# Env vars
+container="$(echo "$ss" | yq '.spec.template.spec.containers[0]')"
+assert_contains "env BOOTSTRAP_CONFIG_FILE" "$container" "/data/bootstrap.dat"
+assert_contains "env BOOTSTRAP_CONFIG_WRITEBACK_URI" "$container" "file:///data/bootstrap.dat"
+assert_contains "env XDG_DATA_HOME" "$container" "/data"
+assert_contains "env TMPDIR" "$container" "/tmp/pomerium"
+assert_contains "volumeMount /data" "$container" "mountPath: /data"
+assert_not_contains "no bootstrap secret mount" "$container" "/var/run/secrets/pomerium"
+
+# No Deployment should be rendered
+assert_eq "no Deployment rendered" "$(select_kind "$out" "Deployment" | yq '.kind')" "null"
+
+# No Role/RoleBinding
+assert_eq "no Role rendered" "$(select_kind "$out" "Role" | yq '.kind')" "null"
+assert_eq "no RoleBinding rendered" "$(select_kind "$out" "RoleBinding" | yq '.kind')" "null"
+
+# ServiceAccount always present
+sa="$(select_kind "$out" "ServiceAccount")"
+assert_eq "ServiceAccount rendered" "$(echo "$sa" | yq '.kind')" "ServiceAccount"
+
+echo ""
+
+# ─── Custom persistence settings ─────────────────────────────────────
+
+echo "Suite: Custom persistence settings"
+
+out="$(render --set persistence.size=10Gi --set persistence.storageClass=gp3)"
+ss="$(select_kind "$out" "StatefulSet")"
+
+assert_eq "custom PVC size" "$(echo "$ss" | yq '.spec.volumeClaimTemplates[0].spec.resources.requests.storage')" "10Gi"
+assert_eq "custom storageClassName" "$(echo "$ss" | yq '.spec.volumeClaimTemplates[0].spec.storageClassName')" "gp3"
+
+echo ""
+
+# ─── Custom replicas ─────────────────────────────────────────────────
+
+echo "Suite: Custom replicas"
+
+out="$(render --set replicaCount=3)"
+ss="$(select_kind "$out" "StatefulSet")"
+assert_eq "replicas 3" "$(echo "$ss" | yq '.spec.replicas')" "3"
+
+echo ""
+
+# ─── Deployment (persistence disabled) ───────────────────────────────
+
+echo "Suite: Deployment (persistence disabled)"
+
+out="$(render --set persistence.enabled=false)"
+dep="$(select_kind "$out" "Deployment")"
+
+assert_eq "renders Deployment" "$(echo "$dep" | yq '.kind')" "Deployment"
+assert_eq "no StatefulSet" "$(select_kind "$out" "StatefulSet" | yq '.kind')" "null"
+
+container="$(echo "$dep" | yq '.spec.template.spec.containers[0]')"
+assert_contains "env BOOTSTRAP_CONFIG_FILE secret path" "$container" "/var/run/secrets/pomerium/bootstrap.dat"
+assert_contains "env BOOTSTRAP_CONFIG_WRITEBACK_URI secret://" "$container" "secret://\$(POMERIUM_NAMESPACE)/test-pomerium-zero/bootstrap"
+assert_contains "env XDG_DATA_HOME /tmp" "$container" "/tmp/pomerium/cache"
+assert_contains "bootstrap volume mount" "$container" "/var/run/secrets/pomerium"
+assert_not_contains "no /data mount" "$container" "mountPath: /data"
+
+# RBAC should include Role + RoleBinding
+assert_eq "Role rendered" "$(select_kind "$out" "Role" | yq '.kind')" "Role"
+assert_eq "RoleBinding rendered" "$(select_kind "$out" "RoleBinding" | yq '.kind')" "RoleBinding"
+
+echo ""
+
+# ─── Service ─────────────────────────────────────────────────────────
+
+echo "Suite: Service"
+
+out="$(render)"
+svc="$(select_kind "$out" "Service")"
+
+assert_eq "Service type LoadBalancer" "$(echo "$svc" | yq '.spec.type')" "LoadBalancer"
+assert_eq "Service port 443" "$(echo "$svc" | yq '.spec.ports[0].port')" "443"
+
+out="$(render --set service.type=NodePort --set service.nodePort=30443)"
+svc="$(select_kind "$out" "Service")"
+assert_eq "NodePort type" "$(echo "$svc" | yq '.spec.type')" "NodePort"
+assert_eq "nodePort 30443" "$(echo "$svc" | yq '.spec.ports[0].nodePort')" "30443"
+
+echo ""
+
+# ─── Image configuration ─────────────────────────────────────────────
+
+echo "Suite: Image"
+
+out="$(render --set image.repository=custom/pomerium --set image.tag=v1.0.0)"
+ss="$(select_kind "$out" "StatefulSet")"
+assert_eq "custom image" "$(echo "$ss" | yq '.spec.template.spec.containers[0].image')" "custom/pomerium:v1.0.0"
+
+echo ""
+
+# ─── Validation ──────────────────────────────────────────────────────
+
+echo "Suite: Validation"
+
+validation_output="$(helm template test "$CHART_DIR" --set 'pomeriumZeroToken=' 2>&1 || true)"
+if echo "$validation_output" | grep -q "pomeriumZeroToken is required"; then
+  pass "fails when token is empty"
+else
+  fail "fails when token is empty" "expected validation error"
+fi
+
+echo ""
+
+# ─── Summary ─────────────────────────────────────────────────────────
+
+echo "─────────────────────────────────"
+echo "Tests: $TESTS  Passed: $((TESTS - FAILURES))  Failed: $FAILURES"
+
+if [ "$FAILURES" -gt 0 ]; then
+  exit 1
+fi

--- a/zero/helm/values.yaml
+++ b/zero/helm/values.yaml
@@ -3,6 +3,9 @@
 # Required: Your Pomerium Zero token
 pomeriumZeroToken: "REPLACE_ME_WITH_YOUR_TOKEN"
 
+# Create the namespace if it doesn't exist
+createNamespace: true
+
 image:
   repository: pomerium/pomerium
   tag: ""

--- a/zero/helm/values.yaml
+++ b/zero/helm/values.yaml
@@ -29,6 +29,16 @@ service:
   type: LoadBalancer
   port: 443
 
+# Persistence settings
+# When enabled, uses a StatefulSet with a PVC for persistent databroker and bootstrap storage.
+# When disabled, uses a Deployment with bootstrap config stored in a Kubernetes Secret.
+persistence:
+  enabled: true
+  storageClass: ""
+  size: 1Gi
+  accessModes:
+    - ReadWriteOnce
+
 # Optional deployment settings
 #
 extraEnvVars: {}


### PR DESCRIPTION
## Summary

- Default workload is now a **StatefulSet** with a PVC, so databroker state and bootstrap config persist across pod restarts
- Bootstrap config writes to the PVC (`file:///data/bootstrap.dat`) instead of a Kubernetes Secret, removing the need for secret-patch RBAC
- Previous Deployment behavior is available via `persistence.enabled: false` for users with external storage (e.g. PostgreSQL)

### New `values.yaml` options

| Parameter | Default | Description |
|---|---|---|
| `persistence.enabled` | `true` | StatefulSet + PVC when true, Deployment when false |
| `persistence.storageClass` | `""` | Storage class (empty = cluster default) |
| `persistence.size` | `1Gi` | PVC size |
| `persistence.accessModes` | `[ReadWriteOnce]` | PVC access modes |

## Test plan

- [ ] `make test` passes (35 unit tests via `helm template` + `yq`)
- [ ] `helm template . --set pomeriumZeroToken=t` renders StatefulSet with PVC
- [ ] `helm template . --set pomeriumZeroToken=t --set persistence.enabled=false` renders Deployment with secret-based bootstrap
- [ ] Deploy to a test cluster and verify PVC is created and data persists across pod restart