### PR TITLE
helm: support referencing an existing secret

### DIFF
--- a/zero/helm/README.md
+++ b/zero/helm/README.md
@@ -41,7 +41,9 @@ helm uninstall pomerium-zero -n pomerium-zero
 
 | Parameter | Description | Default |
 | --- | --- | --- |
-| `pomeriumZeroToken` | Pomerium Zero token (required) | `""` |
+| `pomeriumZeroToken` | Pomerium Zero token (required unless existingSecret is set) | `""` |
+| `existingSecret.name` | Use a pre-existing secret instead of creating one | `""` |
+| `existingSecret.key` | Key in the existing secret | `"pomerium_zero_token"` |
 | `createNamespace` | Create the target namespace | `true` |
 | `image.repository` | Image repository | `pomerium/pomerium` |
 | `image.tag` | Image tag (defaults to appVersion) | `""` |

--- a/zero/helm/templates/_helpers.tpl
+++ b/zero/helm/templates/_helpers.tpl
@@ -63,21 +63,10 @@ Validate required values
 Secret name for the token
 */}}
 {{- define "pomerium-zero.secretName" -}}
-{{- if .Values.existingSecret.name -}}
-{{- .Values.existingSecret.name -}}
+{{- with .Values.existingSecret.name -}}
+{{- . -}}
 {{- else -}}
 {{- include "pomerium-zero.fullname" . -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Secret key for the token
-*/}}
-{{- define "pomerium-zero.secretKey" -}}
-{{- if .Values.existingSecret.name -}}
-{{- .Values.existingSecret.key -}}
-{{- else -}}
-pomerium_zero_token
 {{- end -}}
 {{- end -}}
 
@@ -97,7 +86,7 @@ containers:
         valueFrom:
           secretKeyRef:
             name: {{ include "pomerium-zero.secretName" . }}
-            key: {{ include "pomerium-zero.secretKey" . }}
+            key: {{ .Values.existingSecret.key }}
       - name: POMERIUM_NAMESPACE
         valueFrom:
           fieldRef:

--- a/zero/helm/templates/_helpers.tpl
+++ b/zero/helm/templates/_helpers.tpl
@@ -54,8 +54,30 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Validate required values
 */}}
 {{- define "pomerium-zero.validateValues" -}}
-{{- if not .Values.pomeriumZeroToken -}}
-{{- fail "pomeriumZeroToken is required. Please set it in your values.yaml or provide it via --set flag." -}}
+{{- if and (not .Values.existingSecret.name) (not .Values.pomeriumZeroToken) -}}
+{{- fail "pomeriumZeroToken or existingSecret.name is required." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret name for the token
+*/}}
+{{- define "pomerium-zero.secretName" -}}
+{{- if .Values.existingSecret.name -}}
+{{- .Values.existingSecret.name -}}
+{{- else -}}
+{{- include "pomerium-zero.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Secret key for the token
+*/}}
+{{- define "pomerium-zero.secretKey" -}}
+{{- if .Values.existingSecret.name -}}
+{{- .Values.existingSecret.key -}}
+{{- else -}}
+pomerium_zero_token
 {{- end -}}
 {{- end -}}
 
@@ -74,8 +96,8 @@ containers:
       - name: POMERIUM_ZERO_TOKEN
         valueFrom:
           secretKeyRef:
-            name: {{ include "pomerium-zero.fullname" . }}
-            key: pomerium_zero_token
+            name: {{ include "pomerium-zero.secretName" . }}
+            key: {{ include "pomerium-zero.secretKey" . }}
       - name: POMERIUM_NAMESPACE
         valueFrom:
           fieldRef:
@@ -100,7 +122,7 @@ containers:
       - name: BOOTSTRAP_CONFIG_FILE
         value: "/var/run/secrets/pomerium/bootstrap.dat"
       - name: BOOTSTRAP_CONFIG_WRITEBACK_URI
-        value: "secret://$(POMERIUM_NAMESPACE)/{{ include "pomerium-zero.fullname" . }}/bootstrap"
+        value: "secret://$(POMERIUM_NAMESPACE)/{{ include "pomerium-zero.secretName" . }}/bootstrap"
       - name: XDG_CACHE_HOME
         value: /tmp/pomerium/cache
       - name: XDG_DATA_HOME
@@ -192,7 +214,7 @@ volumes:
       - key: bootstrap
         path: bootstrap.dat
       optional: true
-      secretName: {{ include "pomerium-zero.fullname" . }}
+      secretName: {{ include "pomerium-zero.secretName" . }}
   {{- end }}
   {{- with .Values.extraVolumes }}
   {{- toYaml . | nindent 2 }}

--- a/zero/helm/templates/rbac.yaml
+++ b/zero/helm/templates/rbac.yaml
@@ -20,7 +20,7 @@ rules:
   verbs:
   - patch
   resourceNames:
-  - {{ include "pomerium-zero.fullname" . }}
+  - {{ include "pomerium-zero.secretName" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/zero/helm/templates/secret.yaml
+++ b/zero/helm/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 stringData:
   pomerium_zero_token: {{ .Values.pomeriumZeroToken | quote }}
+{{- end }}

--- a/zero/helm/tests/helm_test.sh
+++ b/zero/helm/tests/helm_test.sh
@@ -156,15 +156,45 @@ assert_eq "no Namespace when createNamespace=false" "$(echo "$ns" | yq '.kind')"
 
 echo ""
 
+# ─── Existing Secret ──────────────────────────────────────────────────
+
+echo "Suite: Existing Secret"
+
+out="$(helm template test "$CHART_DIR" --set existingSecret.name=my-secret --set existingSecret.key=my-key 2>&1)"
+
+# No Secret resource should be rendered
+assert_eq "no Secret rendered" "$(select_kind "$out" "Secret" | yq '.kind')" "null"
+
+# secretKeyRef should point to the existing secret
+ss="$(select_kind "$out" "StatefulSet")"
+container="$(echo "$ss" | yq '.spec.template.spec.containers[0]')"
+assert_contains "secretRef name is my-secret" "$container" "name: my-secret"
+assert_contains "secretRef key is my-key" "$container" "key: my-key"
+
+# Default mode should still create a Secret
+out="$(render)"
+secret="$(select_kind "$out" "Secret")"
+assert_eq "Secret rendered by default" "$(echo "$secret" | yq '.kind')" "Secret"
+
+echo ""
+
 # ─── Validation ──────────────────────────────────────────────────────
 
 echo "Suite: Validation"
 
 validation_output="$(helm template test "$CHART_DIR" --set 'pomeriumZeroToken=' 2>&1 || true)"
-if echo "$validation_output" | grep -q "pomeriumZeroToken is required"; then
-  pass "fails when token is empty"
+if echo "$validation_output" | grep -q "pomeriumZeroToken or existingSecret.name is required"; then
+  pass "fails when neither token nor existingSecret set"
 else
-  fail "fails when token is empty" "expected validation error"
+  fail "fails when neither token nor existingSecret set" "expected validation error"
+fi
+
+# Should succeed with existingSecret alone
+validation_output="$(helm template test "$CHART_DIR" --set 'pomeriumZeroToken=' --set existingSecret.name=my-secret 2>&1 || true)"
+if echo "$validation_output" | grep -q "Error"; then
+  fail "succeeds with existingSecret.name" "expected no error"
+else
+  pass "succeeds with existingSecret.name"
 fi
 
 echo ""

--- a/zero/helm/values.yaml
+++ b/zero/helm/values.yaml
@@ -1,7 +1,12 @@
 # Default values for pomerium-zero Helm chart
 
 # Required: Your Pomerium Zero token
+# Set pomeriumZeroToken to have the chart create and manage the secret,
+# or set existingSecret to reference a pre-existing secret.
 pomeriumZeroToken: "REPLACE_ME_WITH_YOUR_TOKEN"
+existingSecret:
+  name: ""
+  key: "pomerium_zero_token"
 
 # Create the namespace if it doesn't exist
 createNamespace: true


### PR DESCRIPTION
## Summary

- Add `existingSecret.name` and `existingSecret.key` values to reference a pre-existing Kubernetes secret for the Pomerium Zero token
- When `existingSecret.name` is set, the chart skips creating its own Secret and points the `secretKeyRef` to the external one
- Validation accepts either `pomeriumZeroToken` or `existingSecret.name` (at least one required)

### Usage

```yaml
existingSecret:
  name: pomerium
  key: pomerium_zero_token
```

## Test plan

- [ ] `make test` passes (43 unit tests)
- [ ] `helm template . --set existingSecret.name=my-secret` renders without a Secret resource and references the external secret
- [ ] `helm template . --set pomeriumZeroToken=tok` still creates a chart-managed Secret (backwards compatible)
- [ ] Validation fails when neither `pomeriumZeroToken` nor `existingSecret.name` is set