### PR TITLE
helm: add serviceAccount.annotations

### DIFF
--- a/zero/helm/README.md
+++ b/zero/helm/README.md
@@ -45,6 +45,7 @@ helm uninstall pomerium-zero -n pomerium-zero
 | `existingSecret.name` | Use a pre-existing secret instead of creating one | `""` |
 | `existingSecret.key` | Key in the existing secret | `"pomerium_zero_token"` |
 | `createNamespace` | Create the target namespace | `true` |
+| `serviceAccount.annotations` | Annotations for the ServiceAccount (e.g. workload identity) | `{}` |
 | `image.repository` | Image repository | `pomerium/pomerium` |
 | `image.tag` | Image tag (defaults to appVersion) | `""` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |

--- a/zero/helm/templates/rbac.yaml
+++ b/zero/helm/templates/rbac.yaml
@@ -3,6 +3,10 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "pomerium-zero.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: pomerium-zero
 {{- if not .Values.persistence.enabled }}
 ---

--- a/zero/helm/tests/helm_test.sh
+++ b/zero/helm/tests/helm_test.sh
@@ -156,6 +156,20 @@ assert_eq "no Namespace when createNamespace=false" "$(echo "$ns" | yq '.kind')"
 
 echo ""
 
+# ─── ServiceAccount annotations ──────────────────────────────────────
+
+echo "Suite: ServiceAccount annotations"
+
+out="$(render --set 'serviceAccount.annotations.iam\.gke\.io/gcp-service-account=my-gsa@proj.iam.gserviceaccount.com')"
+sa="$(select_kind "$out" "ServiceAccount")"
+assert_contains "SA has workload identity annotation" "$sa" "iam.gke.io/gcp-service-account"
+
+out="$(render)"
+sa="$(select_kind "$out" "ServiceAccount")"
+assert_not_contains "SA has no annotations by default" "$sa" "annotations:"
+
+echo ""
+
 # ─── Existing Secret ──────────────────────────────────────────────────
 
 echo "Suite: Existing Secret"

--- a/zero/helm/values.yaml
+++ b/zero/helm/values.yaml
@@ -16,6 +16,9 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+serviceAccount:
+  annotations: {}
+
 imagePullSecrets: []
 
 replicaCount: 1


### PR DESCRIPTION
OPE-257

Add `serviceAccount.annotations` to the Helm chart so workload identity annotations can be set via GitOps instead of Terraform.