### PR TITLE
helm: use dedicated health endpoint for kubernetes probes

### DIFF
--- a/zero/helm/templates/_helpers.tpl
+++ b/zero/helm/templates/_helpers.tpl
@@ -127,6 +127,9 @@ containers:
       - containerPort: 9090
         name: metrics
         protocol: TCP
+      - containerPort: 28080
+        name: health
+        protocol: TCP
     volumeMounts:
       - name: tmp
         mountPath: /tmp
@@ -145,25 +148,31 @@ containers:
       {{- toYaml .Values.resources | nindent 6 }}
     securityContext:
       {{- toYaml .Values.securityContext | nindent 6 }}
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: https
-        scheme: HTTPS
-      timeoutSeconds: 1
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 3
     startupProbe:
       httpGet:
-        path: /healthz
-        port: https
-        scheme: HTTPS
+        path: /startupz
+        port: health
       initialDelaySeconds: 5
       timeoutSeconds: 1
       periodSeconds: 5
       successThreshold: 1
       failureThreshold: 60
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: health
+      timeoutSeconds: 1
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: health
+      timeoutSeconds: 1
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
   {{- with .Values.extraContainers }}
   {{ toYaml . | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
## Summary
- Switch zero helm chart probes to use pomerium's dedicated health check HTTP server (port 28080) instead of the main HTTPS port
- Add readiness probe (`/readyz`) — previously missing
- Use correct probe-specific paths: `/startupz`, `/healthz`, `/readyz`
- Health port is internal only — not exposed via the Service/LoadBalancer

Tracking: [ENG-3900](https://linear.app/pomerium/issue/ENG-3900/zero-helm-chart-use-dedicated-health-check-endpoint-for-k8s-probes)

## Test plan
- [ ] `helm lint` passes
- [ ] Deploy to staging and verify pod becomes Ready
- [ ] Confirm `kubectl describe pod` shows all three probes hitting port 28080