### PR TITLE
helm: add fsGroup to default podSecurityContext

### DIFF
--- a/zero/helm/values.yaml
+++ b/zero/helm/values.yaml
@@ -63,6 +63,7 @@ initContainers: {}
 #
 # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 podSecurityContext:
+  fsGroup: 65532
   runAsNonRoot: true
   runAsGroup: 65532
   runAsUser: 65532


### PR DESCRIPTION
PVC mounts as root-owned, container runs as 65532 → permission denied writing to /data.

Adding `fsGroup: 65532` makes Kubernetes chown the volume to the container's group on mount.