### PR TITLE
helm: add probes.enabled toggle

### DIFF
--- a/zero/helm/templates/_helpers.tpl
+++ b/zero/helm/templates/_helpers.tpl
@@ -148,6 +148,7 @@ containers:
       {{- toYaml .Values.resources | nindent 6 }}
     securityContext:
       {{- toYaml .Values.securityContext | nindent 6 }}
+    {{- if .Values.probes.enabled }}
     startupProbe:
       httpGet:
         path: /startupz
@@ -173,6 +174,7 @@ containers:
       periodSeconds: 10
       successThreshold: 1
       failureThreshold: 3
+    {{- end }}
   {{- with .Values.extraContainers }}
   {{ toYaml . | nindent 2 }}
   {{- end }}

--- a/zero/helm/values.yaml
+++ b/zero/helm/values.yaml
@@ -50,6 +50,10 @@ persistence:
   accessModes:
     - ReadWriteOnce
 
+# Health probes (disabled by default — health endpoint binds to 127.0.0.1)
+probes:
+  enabled: false
+
 # Optional deployment settings
 #
 extraEnvVars: {}


### PR DESCRIPTION
Adds `probes.enabled` (default `false`) to allow disabling startup/liveness/readiness probes.

The health endpoint binds to `127.0.0.1:28080` which is unreachable from the kubelet, causing startup probe failures. This toggle allows disabling probes as a workaround until the health endpoint is fixed.

Related: 
- https://linear.app/pomerium/issue/ENG-3910/zero-mode-health_check_addr-not-configurable
- https://linear.app/pomerium/issue/ENG-3911/zero-mode-health-listener-bound-to-localhost-makes-k8s-probes