### PR TITLE
feat: add session-recording-options as a variable for enterprise deployments

### DIFF
--- a/enterprise/terraform/kubernetes/deployment.tf
+++ b/enterprise/terraform/kubernetes/deployment.tf
@@ -167,6 +167,11 @@ resource "kubernetes_deployment" "pomerium-console" {
           }
 
           env {
+            name  = "SESSION_RECORDING_OPTIONS"
+            value = var.session_recording_options
+          }
+
+          env {
             name  = "TMPDIR"
             value = "/tmp"
           }

--- a/enterprise/terraform/kubernetes/variables.tf
+++ b/enterprise/terraform/kubernetes/variables.tf
@@ -222,3 +222,9 @@ variable "disable_remote_diagnostics" {
   type        = bool
   default     = false
 }
+
+variable "session_recording_options" {
+  description = "Bootstrap settings (JSON) for session_recording for the default cluster. `datasource_name` (the string id for this datasource) and `bucket_uri` (the storage configuration) must be set. See https://www.pomerium.com/docs/capabilities/session-recording/storage for more details"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Adds bootstrap session recording options for configuration session recording for the default pomerium cluster.

```json
{
  "datasource_name" : "bootstrap",
  "bucket_uri" : "s3://example",
}
```

## Related issues

[ENG-4245](https://linear.app/pomerium/issue/ENG-4245/console-add-static-configuration-option-in-config-file-for-session)

## Checklist

- [X] reference any related issues
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
