### PR TITLE
chore: bump zero helm chart to v0.33.0

### DIFF
--- a/zero/helm/Chart.yaml
+++ b/zero/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pomerium-zero
 description: A Helm chart for deploying Pomerium Zero
 type: application
-version: 0.32.5
-appVersion: v0.32.5
+version: 0.33.0
+appVersion: v0.33.0
 home: https://www.pomerium.com/
 icon: https://www.pomerium.com/static-img/favicon.svg
 sources:


### PR DESCRIPTION
## Summary

Bumps the default versions to v0.33.0

## Related issues

[ENG-4175](https://linear.app/pomerium/issue/ENG-4175/v0330-zero)

## Checklist

- [X] reference any related issues
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
