### PR TITLE
feat: expose all Pomerium CRD config options in ingress-controller terraform

### DIFF
--- a/ingress-controller/terraform/variables.tf
+++ b/ingress-controller/terraform/variables.tf
@@ -217,11 +217,17 @@ variable "config" {
   description = "Pomerium configuration. Set to null to disable config creation. See https://www.pomerium.com/docs/k8s/reference"
   type = object({
     accessLogFields = optional(list(string))
+    allowUpgrades   = optional(list(string))
     authenticate = optional(object({
-      callbackPath = optional(string)
-      url          = string
+      url = string
     }))
-    caSecrets    = optional(list(string))
+    authorizeLogFields = optional(list(string))
+    bearerTokenFormat  = optional(string) # one of: default, idp_access_token, idp_identity_token
+    caSecrets          = optional(list(string))
+    certificateAutoProvision = optional(object({
+      clusterIssuer = optional(string)
+      issuer        = optional(string)
+    }))
     certificates = optional(list(string))
     circuitBreakerThresholds = optional(object({
       maxConnectionPools = optional(number)
@@ -230,12 +236,25 @@ variable "config" {
       maxRequests        = optional(number)
       maxRetries         = optional(number)
     }))
+    codecType = optional(string) # one of: auto, http1, http2, http3
     cookie = optional(object({
       domain   = optional(string)
       expire   = optional(string)
       httpOnly = optional(bool)
       name     = optional(string)
       sameSite = optional(string)
+    }))
+    dataBroker = optional(object({
+      clusterLeaderId = optional(string)
+    }))
+    dns = optional(object({
+      failureRefreshRate = optional(string)
+      lookupFamily       = optional(string)
+      queryTimeout       = optional(string)
+      queryTries         = optional(number)
+      refreshRate        = optional(string)
+      udpMaxQueries      = optional(number)
+      useTcp             = optional(bool)
     }))
     downstreamMtls = optional(object({
       ca          = optional(string)
@@ -250,6 +269,7 @@ variable "config" {
       }))
       maxVerifyDepth = optional(number)
     }))
+    envoyDynamicExtensions = optional(list(string))
     identityProvider = optional(object({
       provider            = string
       requestParams       = optional(map(string))
@@ -258,34 +278,38 @@ variable "config" {
       secret              = string
       url                 = optional(string)
     }))
-    jwtClaimHeaders = optional(map(string))
+    idpAccessTokenAllowedAudiences = optional(list(string))
+    jwtClaimHeaders                = optional(map(string))
+    mcpAllowedAsMetadataDomains    = optional(list(string))
+    mcpAllowedClientIdDomains      = optional(list(string))
     otel = optional(object({
       endpoint              = string # required
       protocol              = string # required
       headers               = optional(map(string))
       timeout               = optional(string)
-      sampling              = optional(number)
+      sampling              = optional(string)
       resourceAttributes    = optional(map(string))
       bspScheduleDelay      = optional(string)
       bspMaxExportBatchSize = optional(number)
       logLevel              = optional(string)
     }))
     passIdentityHeaders         = optional(bool)
-    programmaticRedirectDomains = optional(string)
+    programmaticRedirectDomains = optional(list(string))
     runtimeFlags                = optional(map(bool))
+    setResponseHeaders          = optional(map(string))
     ssh = optional(object({
       hostKeySecrets  = optional(list(string))
       userCaKeySecret = optional(string)
     }))
     storage = optional(object({
-      file = object({
+      file = optional(object({
         path = optional(string)
-      })
-      postgres = object({
+      }))
+      postgres = optional(object({
         caSecret  = optional(string)
         secret    = string
         tlsSecret = optional(string)
-      })
+      }))
     }))
     timeouts = optional(object({
       idle  = optional(string)


### PR DESCRIPTION
## Summary

The ingress-controller terraform module's `config` variable maps 1:1 to the `spec` of the `Pomerium` CRD, but it only exposed **17 of the 30** `spec` fields. This adds the **12 missing top-level knobs** and fixes **3 type mismatches** so every documented CRD setting is reachable from terraform.

**Source of truth:** `ingress-controller` repo `config/crd/bases/ingress.pomerium.io_pomerium.yaml` — confirmed byte-identical to the copy this module reads (`terraform/crd.yaml` → `kustomize/crd/bases/…`), so the gap was purely in `variables.tf`.

## Added knobs

| Field | Type |
|---|---|
| `allowUpgrades` | `list(string)` |
| `authorizeLogFields` | `list(string)` |
| `bearerTokenFormat` | `string` (`default` / `idp_access_token` / `idp_identity_token`) |
| `certificateAutoProvision` | `object({ clusterIssuer, issuer })` |
| `codecType` | `string` (`auto` / `http1` / `http2` / `http3`) |
| `dataBroker` | `object({ clusterLeaderId })` |
| `dns` | `object({ failureRefreshRate, lookupFamily, queryTimeout, queryTries, refreshRate, udpMaxQueries, useTcp })` |
| `envoyDynamicExtensions` | `list(string)` |
| `idpAccessTokenAllowedAudiences` | `list(string)` |
| `mcpAllowedAsMetadataDomains` | `list(string)` |
| `mcpAllowedClientIdDomains` | `list(string)` |
| `setResponseHeaders` | `map(string)` |

## Type mismatch fixes

These fields were exposed but typed incorrectly, so passing a value would be rejected or silently pruned by the API server:

- `programmaticRedirectDomains`: `string` → `list(string)` (CRD is an array)
- `otel.sampling`: `number` → `string` (CRD is a string)
- `authenticate.callbackPath`: **removed** — not present in the CRD's `authenticate` object (stale field)

## Other

- `storage.file` / `storage.postgres` are now `optional`, so a single storage backend can be configured without having to specify both.

## Notes

- `config.tf` is unchanged: its `for k, v in var.config : k => v if v != null` pass-through forwards every new field to the CRD spec generically.
- The two `identityProvider` sub-fields still omitted (`refreshDirectory`, `serviceAccountFromSecret`) are both marked **"no longer supported"** in the CRD, so they were intentionally left out.

## Test plan

- [x] `terraform fmt` clean on changed files
- [x] `terraform validate` passes