### PR TITLE
fix: sync controller ClusterRole RBAC with ingress-controller source

### DIFF
--- a/ingress-controller/terraform/cluster_roles.tf
+++ b/ingress-controller/terraform/cluster_roles.tf
@@ -6,8 +6,14 @@ resource "kubernetes_cluster_role" "controller" {
 
   rule {
     api_groups = [""]
-    resources  = ["services", "endpoints", "secrets"]
+    resources  = ["services", "endpoints"]
     verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["delete", "get", "list", "watch", "patch"]
   }
 
   rule {
@@ -19,7 +25,7 @@ resource "kubernetes_cluster_role" "controller" {
   rule {
     api_groups = ["networking.k8s.io"]
     resources  = ["ingresses", "ingressclasses"]
-    verbs      = ["get", "list", "watch"]
+    verbs      = ["get", "list", "watch", "patch"]
   }
 
   rule {
@@ -44,5 +50,11 @@ resource "kubernetes_cluster_role" "controller" {
     api_groups = [""]
     resources  = ["events"]
     verbs      = ["create", "patch"]
+  }
+
+  rule {
+    api_groups = ["cert-manager.io"]
+    resources  = ["certificates"]
+    verbs      = ["create", "delete", "get", "list", "patch", "watch", "update"]
   }
 }


### PR DESCRIPTION
## Summary

The Terraform module's controller `ClusterRole` (`ingress-controller/terraform/cluster_roles.tf`) had drifted from the source-of-truth RBAC in the ingress-controller repo (`config/pomerium/rbac/cluster_role.yaml`). Three grants were missing:

| Resource | Source | Terraform (before) | Fix |
|---|---|---|---|
| `secrets` | `delete, get, list, watch, patch` | `get, list, watch` | add `patch`, `delete` (split into own rule) |
| `networking.k8s.io` ingresses/ingressclasses | `get, list, watch, patch` | `get, list, watch` | add `patch` |
| `cert-manager.io/certificates` | `create, delete, get, list, patch, watch, update` | *(absent)* | add full rule |

The `cert-manager.io/certificates` rule is the RBAC counterpart to the `certificateAutoProvision` config knob (see #59) — without it, that feature cannot function. Both `secrets: delete` and the cert-manager rule were introduced upstream by the certificate controller (ingress-controller#1407).

## Intentionally not included

- **Namespaced `Role`/`RoleBinding` for `coordination.k8s.io/leases`** — the source ships it, but leader election is only used with the sync API. This module runs `all-in-one` mode (`LeaderElection: false` in `cmd/all_in_one.go`), so the leases Role is not needed.
- **`gen-secrets` Job + ServiceAccount/ClusterRole/ClusterRoleBinding** — the module generates the bootstrap secret natively (`random_bytes` + `tls_private_key` in `secrets.tf`), so the gen-secrets Job and its RBAC are unnecessary.

## Verification

- `terraform fmt` — clean
- `terraform validate` — Success! The configuration is valid.